### PR TITLE
Remove route-breaking hrefs

### DIFF
--- a/src/EventEndingRow.jsx
+++ b/src/EventEndingRow.jsx
@@ -85,7 +85,6 @@ let EventRow = React.createClass({
       ? (
         <a
           key={'sm_' + slot}
-          href='#'
           className={'rbc-show-more'}
           onClick={this._showMore.bind(null, slot)}
         >

--- a/src/Month.jsx
+++ b/src/Month.jsx
@@ -239,7 +239,7 @@ let MonthView = React.createClass({
             'rbc-now': dates.eq(day, new Date(), 'day')
           })}
         >
-          <a href='#' onClick={this._dateClick.bind(null, day)}>
+          <a onClick={this._dateClick.bind(null, day)}>
             { localizer.format(day, this.props.dateFormat, this.props.culture) }
           </a>
         </div>

--- a/src/TimeGrid.jsx
+++ b/src/TimeGrid.jsx
@@ -182,7 +182,7 @@ let TimeGrid = React.createClass({
         className='rbc-header'
         style={segStyle(1, this._slots)}
       >
-        <a href='#' onClick={this._headerClick.bind(null, date)}>
+        <a onClick={this._headerClick.bind(null, date)}>
           { localizer.format(date, dayFormat, culture) }
         </a>
       </div>


### PR DESCRIPTION
Leaving `href="#"` on the `<a>`s consistently redirected the user to the route `/`. I've removed them so that routing is no longer affected by clicking around on the calendar.