### PR TITLE
fix: common.nest() discarding custom components

### DIFF
--- a/src/addons/dragAndDrop/common.js
+++ b/src/addons/dragAndDrop/common.js
@@ -19,7 +19,7 @@ export const mergeComponents = (components = {}, addons) => {
   const result = { ...components }
 
   keys.forEach(key => {
-    result[key] = components[key] ? nest(addons[key]) : addons[key]
+    result[key] = components[key] ? nest(components[key], addons[key]) : addons[key]
   })
   return result
 }


### PR DESCRIPTION
Right now  the addon custom `eventWrapper`, `eventContainerWrapper` and `weekWrapper` overwrite user supplied components.

The implementation already takes this into account, but the user supplied component is not passed to the `nenst()` function.