### PR TITLE
Add `onSelectEvent` & `onDoubleClickEvent` support to Agenda

### DIFF
--- a/src/Agenda.js
+++ b/src/Agenda.js
@@ -63,11 +63,13 @@ class Agenda extends React.Component {
 
   renderDay = (day, events, dayKey) => {
     let {
-      selected,
-      getters,
       accessors,
-      localizer,
       components: { event: Event, date: AgendaDate },
+      getters,
+      localizer,
+      onDoubleClickEvent,
+      onSelectEvent,
+      selected,
     } = this.props
 
     events = events.filter(e =>
@@ -110,7 +112,13 @@ class Agenda extends React.Component {
           <td className="rbc-agenda-time-cell">
             {this.timeRangeLabel(day, event)}
           </td>
-          <td className="rbc-agenda-event-cell">
+          <td
+            className="rbc-agenda-event-cell"
+            onClick={e => onSelectEvent && onSelectEvent(event, e)}
+            onDoubleClick={e =>
+              onDoubleClickEvent && onDoubleClickEvent(event, e)
+            }
+          >
             {Event ? <Event event={event} title={title} /> : title}
           </td>
         </tr>
@@ -194,6 +202,9 @@ Agenda.propTypes = {
   components: PropTypes.object.isRequired,
   getters: PropTypes.object.isRequired,
   localizer: PropTypes.object.isRequired,
+
+  onSelectEvent: PropTypes.func,
+  onDoubleClickEvent: PropTypes.func,
 }
 
 Agenda.defaultProps = {


### PR DESCRIPTION
This adds support for the `onSelectEvent` and the `onDoubleClickEvent` props to the Agenda view. Specifically, if an event in the "Event" column is clicked/doubleClicked, it will trigger the props if they were given.