### PR TITLE
Fix for TimeSlots

### DIFF
--- a/src/utils/TimeSlots.js
+++ b/src/utils/TimeSlots.js
@@ -131,7 +131,7 @@ export function getSlotMetrics({ min: start, max: end, step, timeslots }) {
       const rangeStartMin = positionFromDate(rangeStart)
       const rangeEndMin = positionFromDate(rangeEnd)
       const top =
-        rangeEndMin - rangeStartMin < step && !dates.eq(end, rangeEnd)
+        rangeEndMin > step * (numSlots - 1) && !dates.eq(end, rangeEnd)
           ? ((rangeStartMin - step) / (step * numSlots)) * 100
           : (rangeStartMin / (step * numSlots)) * 100
 

--- a/test/utils/TimeSlots.test.js
+++ b/test/utils/TimeSlots.test.js
@@ -2,8 +2,8 @@ import { getSlotMetrics } from '../../src/utils/TimeSlots'
 import * as dates from '../../src/utils/dates'
 
 describe('getSlotMetrics', () => {
-  const min = dates.startOf(new Date(), 'day')
-  const max = dates.endOf(new Date(), 'day')
+  const min = dates.startOf(new Date(2018, 0, 29, 0, 0, 0), 'day')
+  const max = dates.endOf(new Date(2018, 0, 29, 59, 59, 59), 'day')
   const slotMetrics = getSlotMetrics({ min, max, step: 60, timeslots: 1 })
   test('getSlotMetrics.closestSlotToPosition: always returns timeslot if valid percentage is given', () => {
     expect(slotMetrics.closestSlotToPosition(0)).toBeDefined()
@@ -24,8 +24,8 @@ describe('getSlotMetrics', () => {
 })
 
 describe('getRange', () => {
-  const min = dates.startOf(new Date(), 'day')
-  const max = dates.endOf(new Date(), 'day')
+  const min = dates.startOf(new Date(2018, 0, 29, 0, 0, 0), 'day')
+  const max = dates.endOf(new Date(2018, 0, 29, 59, 59, 59), 'day')
   const slotMetrics = getSlotMetrics({ min, max, step: 60, timeslots: 1 })
 
   test('getRange: 15 minute start of day appointment stays within calendar', () => {


### PR DESCRIPTION
This small pull request fixes Issue #1442 

This issue occurs due to Pull Request #1204 

In the case where the range of an event is less than the step, this unmodified line will cause the position of the event to be positioned too early.

The bug, as demonstrated [here](https://codesandbox.io/s/react-big-calendar-issue-8mz4i)
When the `step` attribute is set to the minimum time, this fixes the issue, as seen [here](https://codesandbox.io/s/react-big-calendar-issue-i8vf9), but this forces a change in UI, which is not desirable.

While this current fix resolves the issue to correctly push any events past the calendar height back within, it has the unfortunate side effect of utilizing the `step` attribute to determine the height. For an arbitrarily large step, this will push it to the top of the large step block.

I welcome any feedback prior to modifying the tests.

