### PR TITLE
Change href=# to href=javascript:void(0) to not break hash routing

### DIFF
--- a/src/DateHeader.js
+++ b/src/DateHeader.js
@@ -7,7 +7,7 @@ const DateHeader = ({ label, drilldownView, onDrillDown }) => {
   }
 
   return (
-    <a href="#" onClick={onDrillDown}>
+    <a href="javascript:void(0)" onClick={onDrillDown}>
       {label}
     </a>
   )

--- a/src/EventEndingRow.js
+++ b/src/EventEndingRow.js
@@ -80,7 +80,7 @@ class EventEndingRow extends React.Component {
     return count ? (
       <a
         key={'sm_' + slot}
-        href="#"
+        href="javascript:void(0)"
         className={'rbc-show-more'}
         onClick={e => this.showMore(slot, e)}
       >

--- a/src/TimeGridHeader.js
+++ b/src/TimeGridHeader.js
@@ -48,7 +48,7 @@ class TimeGridHeader extends React.Component {
         >
           {drilldownView ? (
             <a
-              href="#"
+              href="javascript:void(0)"
               onClick={e => this.handleHeaderClick(date, drilldownView, e)}
             >
               {header}


### PR DESCRIPTION
This patch resolves longstanding issue #477.

Some folks choose to do client-side routing on a web client using the
window.location.hash property.  Manipulating after the # symbol does
not trigger a server request.  There are different ways to achieve
this now, but it is still a valid choice for folks.

This change edits all dummy `<a href="#"...` links to
`<a href="javascript:void(0)" ...` as the latter form achieves the
same results without messing up the client-side routing for folks using
the `window.location.hash` property.