### PR TITLE
Fix dnd/resize action on events which state has changed to draggable/resizable

### DIFF
--- a/src/addons/dragAndDrop/EventWrapper.js
+++ b/src/addons/dragAndDrop/EventWrapper.js
@@ -87,9 +87,14 @@ class EventWrapper extends React.Component {
       ? !!get(event, draggableAccessor)
       : true
 
-    /* Event is not draggable, no need to wrap it */
+    /* Event is not draggable, but we need to wrap it with default element listeners functions
+     * so React can bind event listeners before Selection events are initialized
+     */
     if (!isDraggable) {
-      return children
+      return React.cloneElement(children, {
+        onMouseDown: () => {},
+        onTouchStart: () => {},
+      })
     }
 
     /*

--- a/src/addons/dragAndDrop/common.js
+++ b/src/addons/dragAndDrop/common.js
@@ -19,7 +19,9 @@ export const mergeComponents = (components = {}, addons) => {
   const result = { ...components }
 
   keys.forEach(key => {
-    result[key] = components[key] ? nest(components[key], addons[key]) : addons[key]
+    result[key] = components[key]
+      ? nest(components[key], addons[key])
+      : addons[key]
   })
   return result
 }


### PR DESCRIPTION
This fix refers to this issue #1105 the problem happens when we are using draggable or resizable accessors, and events initially aren't draggable or resizable but after this state changes, they become and are rendered with `onMouseDown ` and `onTouchStart `. And this causes a problem because these events are bubbled by react (binded to document) after Selection initialization and Selection listeners are called before Event component.

The hack is to make possible for react bubble this events before Selection listeners are initialized.

I've also described this behaviour in react repo issue https://github.com/facebook/react/issues/17877 but to be honest I don't think its react bug because of how events are managed in react there is no option to manage custom events which are set in `cDM` or `useEffect`.