### PR TITLE
bump memoize-one and migrate new isEqual API

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "invariant": "^2.2.4",
     "lodash": "^4.17.11",
     "lodash-es": "^4.17.11",
-    "memoize-one": "^4.0.3",
+    "memoize-one": "^5.1.1",
     "prop-types": "^15.6.2",
     "react-overlays": "^2.0.0-0",
     "uncontrollable": "^7.0.0"

--- a/src/utils/DateSlotMetrics.js
+++ b/src/utils/DateSlotMetrics.js
@@ -4,7 +4,8 @@ import { eventSegments, endOfRange, eventLevels } from './eventLevels'
 
 let isSegmentInSlot = (seg, slot) => seg.left <= slot && seg.right >= slot
 
-const isEqual = (a, b) => a.range === b.range && a.events === b.events
+const isEqual = (a, b) =>
+  a[0].range === b[0].range && a[0].events === b[0].events
 
 export function getSlotMetrics() {
   return memoize(options => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8531,10 +8531,10 @@ mem@^4.0.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
-memoize-one@^4.0.3:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.1.0.tgz#a2387c58c03fff27ca390c31b764a79addf3f906"
-  integrity sha512-2GApq0yI/b22J2j9rhbrAlsHb0Qcz+7yWxeLG8h+95sl1XPUgeLimQSOdur4Vw7cUhrBHwaUZxWFZueojqNRzA==
+memoize-one@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
+  integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
 
 memoizerific@^1.11.3:
   version "1.11.3"


### PR DESCRIPTION
The memoize-one team updated the isEqual API in version 5.0.0: https://github.com/alexreardon/memoize-one/releases/tag/v5.0.0

I'm taking that dependency bump and migrating the usage of isEqual here.