### PR TITLE
Date-fns localizer - display dayFormat correctly

### DIFF
--- a/src/localizers/date-fns.js
+++ b/src/localizers/date-fns.js
@@ -22,7 +22,7 @@ let weekRangeFormat = ({ start, end }, culture, local) =>
 
 export let formats = {
   dateFormat: 'dd',
-  dayFormat: 'dd ddd',
+  dayFormat: 'dd eee',
   weekdayFormat: 'cccc',
 
   selectRangeFormat: timeRangeFormat,


### PR DESCRIPTION
Previous format string displayed a day as '13 013' when using date-fns, rather than '13 Fri' as
RBC would with the moment localizer.