### PR TITLE
Prevent endless loop when adding event the DST begin day

### DIFF
--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -349,7 +349,7 @@ class DayColumn extends React.Component {
 
     while (dates.lte(current, endDate)) {
       slots.push(current)
-      current = new Date(+current + this.props.step * 60 * 1000)
+      current = new Date(+current + this.props.step * 60 * 1000) // using Date ensures not to create an endless loop the day DST begins
     }
 
     notify(this.props.onSelectSlot, {

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -349,7 +349,7 @@ class DayColumn extends React.Component {
 
     while (dates.lte(current, endDate)) {
       slots.push(current)
-      current = dates.add(current, this.props.step, 'minutes')
+      current = new Date(+current + this.props.step * 60 * 1000)
     }
 
     notify(this.props.onSelectSlot, {


### PR DESCRIPTION
Fix addressing issue https://github.com/jquense/react-big-calendar/issues/1632.

Actually the fix should be reviewed cause even if it suits my needs, I am not sure it does not introduce a new bug.

The loop where the patch is located is in a function that notifies for a selected slot and contains the start, the end time and an array of times (slots), all Date objects. If one selects a slot from 0:00 to 3:15 (the day DST begins), the slot is

```
(10) […]
​0: Date Sun Mar 28 2021 00:00:00 GMT+0100 (Central European Standard Time)
​1: Date Sun Mar 28 2021 00:15:00 GMT+0100 (Central European Standard Time)
​2: Date Sun Mar 28 2021 00:30:00 GMT+0100 (Central European Standard Time)
​3: Date Sun Mar 28 2021 00:45:00 GMT+0100 (Central European Standard Time)
​4: Date Sun Mar 28 2021 01:00:00 GMT+0100 (Central European Standard Time)
​5: Date Sun Mar 28 2021 01:15:00 GMT+0100 (Central European Standard Time)
​6: Date Sun Mar 28 2021 01:30:00 GMT+0100 (Central European Standard Time)
​7: Date Sun Mar 28 2021 01:45:00 GMT+0100 (Central European Standard Time)
​8: Date Sun Mar 28 2021 03:00:00 GMT+0200 (Central European Summer Time)
​9: Date Sun Mar 28 2021 03:15:00 GMT+0200 (Central European Summer Time)
​length: 10
​<prototype>: Array []
```
Notice the gap between 1:45 and 3:00 (2 o'clock jumps to 3 o'clock as expected).
