### PR TITLE
chore(vers): upgrade prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "lodash": "^4.17.11",
     "lodash-es": "^4.17.11",
     "memoize-one": "^5.1.1",
-    "prop-types": "^15.6.2",
+    "prop-types": "^15.7.2",
     "react-overlays": "^2.0.0-0",
     "uncontrollable": "^7.0.0"
   },


### PR DESCRIPTION
In response to [Issue 1651](https://github.com/jquense/react-big-calendar/issues/1651) in the original repo.