### PR TITLE
Update the agenda view to not show date color.

### DIFF
--- a/src/Agenda.js
+++ b/src/Agenda.js
@@ -113,14 +113,19 @@ class Agenda extends React.Component {
       return (
         <tr
           key={dayKey + '_' + idx}
-          className={userProps.className}
-          style={userProps.style}
+          className={userProps.className}          
         >
           {first}
-          <td className="rbc-agenda-time-cell">
+          <td 
+            className="rbc-agenda-time-cell"
+            style={userProps.style}
+          >
             {this.timeRangeLabel(day, event)}
           </td>
-          <td className="rbc-agenda-event-cell">
+          <td 
+            className="rbc-agenda-event-cell"
+            style={userProps.style}
+          >
             {Event ? <Event event={event} title={title} /> : title}
           </td>
         </tr>


### PR DESCRIPTION
Currently when you run the agenda view and utilize background colors for events the Date column for the Agenda view will display in the color of the first event for that day.  This happens because the Date field is a TD within the first TR and the TR is what is set with a color.  

Instead to alleviate this confusion I would move the styling to the Time and Event TD instead of putting it on the TR.  This way it will end up with the Date field having no color since setting any color to this on a day which could have multiple events of different colors is just confusing to users.

Final Result is that the Date column has no color associated to it unless defined in the CSS style sheet.

![image](https://user-images.githubusercontent.com/7444929/81603536-82641600-939c-11ea-92c6-64fa1137a6bb.png)
