### PR TITLE
fixed return type for View parameter

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -250,7 +250,7 @@ class Calendar extends React.Component {
     /**
      *
      * ```js
-     * (dates: Date[] | { start: Date; end: Date }, view?: 'month'|'week'|'work_week'|'day'|'agenda') => void
+     * (dates: Date[] | { start: Date; end: Date }, view: 'month'|'week'|'work_week'|'day'|'agenda'|undefined) => void
      * ```
      *
      * Callback fired when the visible date range changes. Returns an Array of dates
@@ -486,14 +486,23 @@ class Calendar extends React.Component {
 
     /**
      * Optionally provide a function that returns an object of className or style props
-     * to be applied to the the time-slot node. Caution! Styles that change layout or
+     * to be applied to the time-slot node. Caution! Styles that change layout or
      * position may break the calendar in unexpected ways.
      *
      * ```js
      * (date: Date, resourceId: (number|string)) => { className?: string, style?: Object }
      * ```
      */
-    slotPropGetter: PropTypes.func,
+	slotPropGetter: PropTypes.func,
+	
+	/**
+	 * Optionally provide a function that returns an object of props to be applied 
+	 * to the time-slot group node. Useful to dynamically change the sizing of time nodes.
+	 * ```js
+	 * () => { style?: Object }
+	 * ```
+	 */
+	slotGroupPropGetter: PropTypes.func,
 
     /**
      * Optionally provide a function that returns an object of className or style props
@@ -775,7 +784,8 @@ class Calendar extends React.Component {
     resourceIdAccessor,
     resourceTitleAccessor,
     eventPropGetter,
-    slotPropGetter,
+	slotPropGetter,
+	slotGroupPropGetter,
     dayPropGetter,
     view,
     views,
@@ -794,7 +804,9 @@ class Calendar extends React.Component {
         eventProp: (...args) =>
           (eventPropGetter && eventPropGetter(...args)) || {},
         slotProp: (...args) =>
-          (slotPropGetter && slotPropGetter(...args)) || {},
+		  (slotPropGetter && slotPropGetter(...args)) || {},
+		slotGroupProp: (...args) =>
+		  (slotGroupPropGetter && slotGroupPropGetter(...args)) || {},
         dayProp: (...args) => (dayPropGetter && dayPropGetter(...args)) || {},
       },
       components: defaults(components[view] || {}, omit(components, names), {


### PR DESCRIPTION
The types declaration of onRangeChange function are wrong: onRangeChange function always returns also the view parameter (undefined when clicking on next/prev buttons but valued when changing view).
https://codesandbox.io/s/goofy-noether-6kgst

I've already asked for an update also on related typescript library here:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45358