### PR TITLE
DnD plugin: fully support custom event objects

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "./dist/react-big-calendar.js": {
-    "bundled": 507436,
-    "minified": 149016,
-    "gzipped": 45496
+    "bundled": 509838,
+    "minified": 150041,
+    "gzipped": 45816
   },
   "./dist/react-big-calendar.min.js": {
-    "bundled": 444328,
-    "minified": 130089,
-    "gzipped": 41174
+    "bundled": 446582,
+    "minified": 131045,
+    "gzipped": 41386
   },
   "dist/react-big-calendar.esm.js": {
-    "bundled": 174497,
-    "minified": 83179,
-    "gzipped": 20739,
+    "bundled": 176659,
+    "minified": 84434,
+    "gzipped": 21066,
     "treeshaked": {
       "rollup": {
-        "code": 60400,
-        "import_statements": 1578
+        "code": 60322,
+        "import_statements": 1590
       },
       "webpack": {
-        "code": 64923
+        "code": 64842
       }
     }
   }

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -493,16 +493,16 @@ class Calendar extends React.Component {
      * (date: Date, resourceId: (number|string)) => { className?: string, style?: Object }
      * ```
      */
-	slotPropGetter: PropTypes.func,
-	
-	/**
-	 * Optionally provide a function that returns an object of props to be applied 
-	 * to the time-slot group node. Useful to dynamically change the sizing of time nodes.
-	 * ```js
-	 * () => { style?: Object }
-	 * ```
-	 */
-	slotGroupPropGetter: PropTypes.func,
+    slotPropGetter: PropTypes.func,
+
+    /**
+     * Optionally provide a function that returns an object of props to be applied
+     * to the time-slot group node. Useful to dynamically change the sizing of time nodes.
+     * ```js
+     * () => { style?: Object }
+     * ```
+     */
+    slotGroupPropGetter: PropTypes.func,
 
     /**
      * Optionally provide a function that returns an object of className or style props
@@ -754,6 +754,7 @@ class Calendar extends React.Component {
     allDayAccessor: 'allDay',
     startAccessor: 'start',
     endAccessor: 'end',
+    eventUpdater: (event, eventUpdates) => ({ ...event, ...eventUpdates }),
     resourceAccessor: 'resourceId',
 
     resourceIdAccessor: 'id',
@@ -777,6 +778,7 @@ class Calendar extends React.Component {
   getContext({
     startAccessor,
     endAccessor,
+    eventUpdater,
     allDayAccessor,
     tooltipAccessor,
     titleAccessor,
@@ -784,8 +786,8 @@ class Calendar extends React.Component {
     resourceIdAccessor,
     resourceTitleAccessor,
     eventPropGetter,
-	slotPropGetter,
-	slotGroupPropGetter,
+    slotPropGetter,
+    slotGroupPropGetter,
     dayPropGetter,
     view,
     views,
@@ -804,9 +806,9 @@ class Calendar extends React.Component {
         eventProp: (...args) =>
           (eventPropGetter && eventPropGetter(...args)) || {},
         slotProp: (...args) =>
-		  (slotPropGetter && slotPropGetter(...args)) || {},
-		slotGroupProp: (...args) =>
-		  (slotGroupPropGetter && slotGroupPropGetter(...args)) || {},
+          (slotPropGetter && slotPropGetter(...args)) || {},
+        slotGroupProp: (...args) =>
+          (slotGroupPropGetter && slotGroupPropGetter(...args)) || {},
         dayProp: (...args) => (dayPropGetter && dayPropGetter(...args)) || {},
       },
       components: defaults(components[view] || {}, omit(components, names), {
@@ -819,6 +821,7 @@ class Calendar extends React.Component {
       accessors: {
         start: wrapAccessor(startAccessor),
         end: wrapAccessor(endAccessor),
+        eventUpdater: wrapAccessor(eventUpdater),
         allDay: wrapAccessor(allDayAccessor),
         tooltip: wrapAccessor(tooltipAccessor),
         title: wrapAccessor(titleAccessor),

--- a/src/addons/dragAndDrop/EventContainerWrapper.js
+++ b/src/addons/dragAndDrop/EventContainerWrapper.js
@@ -58,18 +58,25 @@ class EventContainerWrapper extends React.Component {
 
   update(event, { startDate, endDate, top, height }) {
     const { event: lastEvent } = this.state
+    const { accessors } = this.props
+
     if (
       lastEvent &&
-      startDate === lastEvent.start &&
-      endDate === lastEvent.end
+      startDate === accessors.start(lastEvent) &&
+      endDate === accessors.end(lastEvent)
     ) {
       return
     }
 
+    const updatedEvent = accessors.eventUpdater(event, {
+      start: startDate,
+      end: endDate,
+    })
+
     this.setState({
       top,
       height,
-      event: { ...event, start: startDate, end: endDate },
+      event: updatedEvent,
     })
   }
 
@@ -202,14 +209,14 @@ class EventContainerWrapper extends React.Component {
   }
 
   handleInteractionEnd = () => {
-    const { resource } = this.props
+    const { resource, accessors } = this.props
     const { event } = this.state
 
     this.reset()
 
     this.context.draggable.onEnd({
-      start: event.start,
-      end: event.end,
+      start: accessors.start(event),
+      end: accessors.end(event),
       resourceId: resource,
     })
   }
@@ -235,7 +242,8 @@ class EventContainerWrapper extends React.Component {
     if (!event) return children
 
     const events = children.props.children
-    const { start, end } = event
+    const start = accessors.start(event)
+    const end = accessors.end(event)
 
     let label
     let format = 'eventTimeRangeFormat'

--- a/src/addons/dragAndDrop/WeekWrapper.js
+++ b/src/addons/dragAndDrop/WeekWrapper.js
@@ -61,8 +61,12 @@ class WeekWrapper extends React.Component {
   }
 
   update(event, start, end) {
+    const { accessors } = this.props
+    const updatedEvent = accessors.eventUpdater(event, { start, end })
+    updatedEvent.__isPreview = true
+
     const segment = eventSegments(
-      { ...event, end, start, __isPreview: true },
+      updatedEvent,
       this.props.slotMetrics.range,
       dragAccessors
     )
@@ -248,14 +252,14 @@ class WeekWrapper extends React.Component {
   }
 
   handleInteractionEnd = () => {
-    const { resourceId, isAllDay } = this.props
+    const { resourceId, isAllDay, accessors } = this.props
     const { event } = this.state.segment
 
     this.reset()
 
     this.context.draggable.onEnd({
-      start: event.start,
-      end: event.end,
+      start: accessors.start(event),
+      end: accessors.end(event),
       resourceId,
       isAllDay,
     })

--- a/src/utils/accessors.js
+++ b/src/utils/accessors.js
@@ -5,10 +5,9 @@
  *    accessor(data, func)    // => retrieves func(data)
  *    ... otherwise null
  */
-export function accessor(data, field) {
+export function accessor(data, field, extraArgs) {
   var value = null
-
-  if (typeof field === 'function') value = field(data)
+  if (typeof field === 'function') value = field(data, ...extraArgs)
   else if (
     typeof field === 'string' &&
     typeof data === 'object' &&
@@ -20,4 +19,5 @@ export function accessor(data, field) {
   return value
 }
 
-export const wrapAccessor = acc => data => accessor(data, acc)
+export const wrapAccessor = acc => (data, ...extraArgs) =>
+  accessor(data, acc, extraArgs)


### PR DESCRIPTION
While trying to use the drag and drop plugin with ImmutableJS
events I was getting a number of errors which were caused by
my custom accessors getting some close but not quite JS objects
rather than my glorious ImmutableJS Maps /s

Eventually I narrowed it down to the `update` function in
EventContainerWrapper - which in essence is creating a new
version of the event object in state with modified start & end
times.

Unfortunately it was simply doing this by treating the event as
a regular JS object with start & end attributes.  This is then
consumed by the TimeGridEvent component, which tries to use the
accessors again and then we're in trouble...

The fix involves creating customisable `updateEvent` function which
follows the same path as the `accessors` -- not 100% sure it's the
best, but it works for my purposes!

Also it could be that I'm just abusing the small amount of power
I was given with the accessors, but it felt a little odd to run into
an issue after having it work so well elsewhere!