### PR TITLE
Documentation: clarify the time unit for 'step'

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -454,7 +454,7 @@ class Calendar extends React.Component {
     longPressThreshold: PropTypes.number,
 
     /**
-     * Determines the selectable time increments in week and day views
+     * Determines the selectable time increments in week and day views, in minutes.
      */
     step: PropTypes.number,
 


### PR DESCRIPTION
The `step` property accepts minutes but this is not explicitly mentioned. Although the default value of `30` suggests that minutes should be given, this is not immediately obvious.