### PR TITLE
intljusticemission renamed to jquense

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/intljusticemission/react-big-calendar.git"
+    "url": "git+https://github.com/jquense/react-big-calendar.git"
   },
   "license": "MIT",
   "main": "lib/index.js",
@@ -144,9 +144,9 @@
     "babel-core": "7.0.0-bridge.0"
   },
   "bugs": {
-    "url": "https://github.com/intljusticemission/react-big-calendar/issues"
+    "url": "https://github.com/jquense/react-big-calendar/issues"
   },
   "readme": "ERROR: No README data found!",
-  "homepage": "https://github.com/intljusticemission/react-big-calendar#readme",
+  "homepage": "https://github.com/jquense/react-big-calendar#readme",
   "_id": "react-big-calendar@0.22.1"
 }


### PR DESCRIPTION
Reflect new repo location.

This also fixes the following linting error on [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped):

```
Error: At least one of the project urls listed in the header, ["https://github.com/jquense/react-big-calendar"], must match the homepage listed by npm, 'https://github.com/intljusticemission/react-big-calendar'.
If your d.ts file is not for the npm package with URL https://github.com/intljusticemission/react-big-calendar,
change the name by adding -browser to the end and change the first line
of the Definitely Typed header to

    // Type definitions for non-npm package react-big-calendar-browser

    at check (/Users/sebu/Devel/_forks/DefinitelyTyped/node_modules/dts-critic/index.js:169:23)
    at dtsCritic (/Users/sebu/Devel/_forks/DefinitelyTyped/node_modules/dts-critic/index.js:20:5)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! definitely-typed@0.0.3 lint: `dtslint types "react-big-calendar"`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the definitely-typed@0.0.3 lint script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```