### PR TITLE
Fix top part of 24hour event in week/day view

### DIFF
--- a/src/utils/TimeSlots.js
+++ b/src/utils/TimeSlots.js
@@ -131,7 +131,7 @@ export function getSlotMetrics({ min: start, max: end, step, timeslots }) {
       const rangeStartMin = positionFromDate(rangeStart)
       const rangeEndMin = positionFromDate(rangeEnd)
       const top =
-        rangeEndMin > step * (numSlots - 1) && !dates.eq(end, rangeEnd)
+        rangeEndMin > step * numSlots && !dates.eq(end, rangeEnd)
           ? ((rangeStartMin - step) / (step * numSlots)) * 100
           : (rangeStartMin / (step * numSlots)) * 100
 


### PR DESCRIPTION
ref: #1646 

`rangeEndMin > step * (numSlots - 1)` will cause the event(`00:00 ~ 23:31(to 23:59)`) shift to wrong position.