### PR TITLE
adds resourceId to handleSelectAllDaySlot fns slotInfo

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "./dist/react-big-calendar.js": {
-    "bundled": 507436,
-    "minified": 149016,
-    "gzipped": 45496
+    "bundled": 509547,
+    "minified": 149932,
+    "gzipped": 45769
   },
   "./dist/react-big-calendar.min.js": {
-    "bundled": 444328,
-    "minified": 130089,
-    "gzipped": 41174
+    "bundled": 446246,
+    "minified": 130919,
+    "gzipped": 41339
   },
   "dist/react-big-calendar.esm.js": {
-    "bundled": 174497,
-    "minified": 83179,
-    "gzipped": 20739,
+    "bundled": 176376,
+    "minified": 84316,
+    "gzipped": 21023,
     "treeshaked": {
       "rollup": {
-        "code": 60400,
-        "import_statements": 1578
+        "code": 60196,
+        "import_statements": 1590
       },
       "webpack": {
-        "code": 64923
+        "code": 64714
       }
     }
   }

--- a/src/BackgroundCells.js
+++ b/src/BackgroundCells.js
@@ -160,6 +160,7 @@ class BackgroundCells extends React.Component {
           action,
           bounds,
           box,
+          resourceId: this.props.resourceId,
         })
   }
 }
@@ -183,6 +184,7 @@ BackgroundCells.propTypes = {
   range: PropTypes.arrayOf(PropTypes.instanceOf(Date)),
   rtl: PropTypes.bool,
   type: PropTypes.string,
+  resourceId: PropTypes.any,
 }
 
 export default BackgroundCells

--- a/src/DateContentRow.js
+++ b/src/DateContentRow.js
@@ -152,6 +152,7 @@ class DateContentRow extends React.Component {
           onSelectSlot={this.handleSelectSlot}
           components={components}
           longPressThreshold={longPressThreshold}
+          resourceId={resourceId}
         />
 
         <div className="rbc-row-content">

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -101,6 +101,7 @@ export default class TimeGrid extends Component {
       start: slots[0],
       end: slots[slots.length - 1],
       action: slotInfo.action,
+      resourceId: slotInfo.resourceId,
     })
   }
 


### PR DESCRIPTION
Apologies, I couldn't find any specs in regards to contributions format, etc. Happy to make changes/add additional info if I missed a guideline doc.

**Context for PR:**
Currently when using resources `onSelectSlot` returns the `resourceId` with the `slotInfo` when selecting within the `DayColumn`.  Unfortunately, when selecting within the `DateContentRow` (rendered by `TimeGridHeader`, the all day events area) it fails to return the `resourceId` with the `slotInfo`.

This PR aims to add that additional argument to the `slotInfo` in order to remain consistent and identify which resource is being selected when a user is clicking, dragging, dblclick within the all day area.

Again, happy to make changes or take guidance on a more preferred method of implementation (as well as format of PR submittals if I missed a guideline).

Thanks!! 