### PR TITLE
<React.StrictMode>-compliance

### DIFF
--- a/examples/App.js
+++ b/examples/App.js
@@ -168,5 +168,10 @@ class Example extends React.Component {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  render(<Example />, document.getElementById('app'))
+  render(
+    <React.StrictMode>
+      <Example />
+    </React.StrictMode>,
+    document.getElementById('app')
+  )
 })

--- a/src/BackgroundCells.js
+++ b/src/BackgroundCells.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import { findDOMNode } from 'react-dom'
 import clsx from 'clsx'
 
 import * as dates from './utils/dates'
@@ -15,6 +14,7 @@ class BackgroundCells extends React.Component {
     this.state = {
       selecting: false,
     }
+    this.ref = React.createRef()
   }
 
   componentDidMount() {
@@ -25,10 +25,10 @@ class BackgroundCells extends React.Component {
     this._teardownSelectable()
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (nextProps.selectable && !this.props.selectable) this._selectable()
+  componentDidUpdate(prevProps) {
+    if (!prevProps.selectable && this.props.selectable) this._selectable()
 
-    if (!nextProps.selectable && this.props.selectable)
+    if (prevProps.selectable && !this.props.selectable)
       this._teardownSelectable()
   }
 
@@ -44,7 +44,7 @@ class BackgroundCells extends React.Component {
     let current = getNow()
 
     return (
-      <div className="rbc-row-bg">
+      <div ref={this.ref} className="rbc-row-bg">
         {range.map((date, index) => {
           let selected = selecting && index >= startIdx && index <= endIdx
           const { className, style } = getters.dayProp(date)
@@ -71,13 +71,13 @@ class BackgroundCells extends React.Component {
   }
 
   _selectable() {
-    let node = findDOMNode(this)
+    let node = this.ref.current
     let selector = (this._selector = new Selection(this.props.container, {
       longPressThreshold: this.props.longPressThreshold,
     }))
 
     let selectorClicksHandler = (point, actionType) => {
-      if (!isEvent(findDOMNode(this), point)) {
+      if (!isEvent(node, point)) {
         let rowBox = getBoundsForNode(node)
         let { range, rtl } = this.props
 
@@ -128,7 +128,7 @@ class BackgroundCells extends React.Component {
     selector.on('beforeSelect', box => {
       if (this.props.selectable !== 'ignoreEvents') return
 
-      return !isEvent(findDOMNode(this), box)
+      return !isEvent(this.ref.current, box)
     })
 
     selector.on('click', point => selectorClicksHandler(point, 'click'))

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -493,16 +493,16 @@ class Calendar extends React.Component {
      * (date: Date, resourceId: (number|string)) => { className?: string, style?: Object }
      * ```
      */
-	slotPropGetter: PropTypes.func,
-	
-	/**
-	 * Optionally provide a function that returns an object of props to be applied 
-	 * to the time-slot group node. Useful to dynamically change the sizing of time nodes.
-	 * ```js
-	 * () => { style?: Object }
-	 * ```
-	 */
-	slotGroupPropGetter: PropTypes.func,
+    slotPropGetter: PropTypes.func,
+
+    /**
+     * Optionally provide a function that returns an object of props to be applied
+     * to the time-slot group node. Useful to dynamically change the sizing of time nodes.
+     * ```js
+     * () => { style?: Object }
+     * ```
+     */
+    slotGroupPropGetter: PropTypes.func,
 
     /**
      * Optionally provide a function that returns an object of className or style props
@@ -767,14 +767,15 @@ class Calendar extends React.Component {
   constructor(...args) {
     super(...args)
     this.state = {
-      context: this.getContext(this.props),
+      context: Calendar.getContext(this.props),
     }
   }
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    this.setState({ context: this.getContext(nextProps) })
+
+  static getDerivedStateFromProps(nextProps) {
+    return { context: Calendar.getContext(nextProps) }
   }
 
-  getContext({
+  static getContext({
     startAccessor,
     endAccessor,
     allDayAccessor,
@@ -784,8 +785,8 @@ class Calendar extends React.Component {
     resourceIdAccessor,
     resourceTitleAccessor,
     eventPropGetter,
-	slotPropGetter,
-	slotGroupPropGetter,
+    slotPropGetter,
+    slotGroupPropGetter,
     dayPropGetter,
     view,
     views,
@@ -804,9 +805,9 @@ class Calendar extends React.Component {
         eventProp: (...args) =>
           (eventPropGetter && eventPropGetter(...args)) || {},
         slotProp: (...args) =>
-		  (slotPropGetter && slotPropGetter(...args)) || {},
-		slotGroupProp: (...args) =>
-		  (slotGroupPropGetter && slotGroupPropGetter(...args)) || {},
+          (slotPropGetter && slotPropGetter(...args)) || {},
+        slotGroupProp: (...args) =>
+          (slotGroupPropGetter && slotGroupPropGetter(...args)) || {},
         dayProp: (...args) => (dayPropGetter && dayPropGetter(...args)) || {},
       },
       components: defaults(components[view] || {}, omit(components, names), {

--- a/src/DateContentRow.js
+++ b/src/DateContentRow.js
@@ -3,7 +3,6 @@ import getHeight from 'dom-helpers/height'
 import qsa from 'dom-helpers/querySelectorAll'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { findDOMNode } from 'react-dom'
 
 import * as dates from './utils/dates'
 import BackgroundCells from './BackgroundCells'
@@ -16,6 +15,7 @@ class DateContentRow extends React.Component {
     super(...args)
 
     this.slotMetrics = DateSlotMetrics.getSlotMetrics()
+    this.ref = React.createRef()
   }
 
   handleSelectSlot = slot => {
@@ -27,7 +27,7 @@ class DateContentRow extends React.Component {
   handleShowMore = (slot, target) => {
     const { range, onShowMore } = this.props
     let metrics = this.slotMetrics(this.props)
-    let row = qsa(findDOMNode(this), '.rbc-row-bg')[0]
+    let row = qsa(this.ref.current, '.rbc-row-bg')[0]
 
     let cell
     if (row) cell = row.children[slot - 1]
@@ -46,13 +46,13 @@ class DateContentRow extends React.Component {
 
   getContainer = () => {
     const { container } = this.props
-    return container ? container() : findDOMNode(this)
+    return container ? container() : this.ref.current
   }
 
   getRowLimit() {
     let eventHeight = getHeight(this.eventRow)
     let headingHeight = this.headingRow ? getHeight(this.headingRow) : 0
-    let eventSpace = getHeight(findDOMNode(this)) - headingHeight
+    let eventSpace = getHeight(this.ref.current) - headingHeight
 
     return Math.max(Math.floor(eventSpace / eventHeight), 1)
   }
@@ -73,7 +73,7 @@ class DateContentRow extends React.Component {
   renderDummy = () => {
     let { className, range, renderHeader } = this.props
     return (
-      <div className={className}>
+      <div ref={this.ref} className={className}>
         <div className="rbc-row-content">
           {renderHeader && (
             <div className="rbc-row" ref={this.createHeadingRef}>
@@ -138,7 +138,7 @@ class DateContentRow extends React.Component {
     }
 
     return (
-      <div className={className}>
+      <div ref={this.ref} className={className}>
         <BackgroundCells
           date={date}
           getNow={getNow}

--- a/src/Month.js
+++ b/src/Month.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import { findDOMNode } from 'react-dom'
 import clsx from 'clsx'
 
 import * as dates from './utils/dates'
@@ -29,16 +28,19 @@ class MonthView extends React.Component {
     this._bgRows = []
     this._pendingSelection = []
     this.slotRowRef = React.createRef()
+    this.ref = React.createRef()
     this.state = {
       rowLimit: 5,
       needLimitMeasure: true,
+      date: null,
     }
   }
 
-  UNSAFE_componentWillReceiveProps({ date }) {
-    this.setState({
-      needLimitMeasure: !dates.eq(date, this.props.date, 'month'),
-    })
+  static getDerivedStateFromProps({ date }, state) {
+    return {
+      needLimitMeasure: !dates.eq(date, state.date, 'month'),
+      date,
+    }
   }
 
   componentDidMount() {
@@ -69,7 +71,7 @@ class MonthView extends React.Component {
   }
 
   getContainer = () => {
-    return findDOMNode(this)
+    return this.ref.current
   }
 
   render() {
@@ -80,7 +82,7 @@ class MonthView extends React.Component {
     this._weekCount = weeks.length
 
     return (
-      <div className={clsx('rbc-month-view', className)}>
+      <div ref={this.ref} className={clsx('rbc-month-view', className)}>
         <div className="rbc-row rbc-month-header">
           {this.renderHeaders(weeks[0])}
         </div>
@@ -263,7 +265,7 @@ class MonthView extends React.Component {
     this.clearSelection()
 
     if (popup) {
-      let position = getPosition(cell, findDOMNode(this))
+      let position = getPosition(cell, this.ref.current)
 
       this.setState({
         overlay: { date, events, position, target },

--- a/src/TimeGutter.js
+++ b/src/TimeGutter.js
@@ -16,11 +16,7 @@ export default class TimeGutter extends Component {
       timeslots,
       step,
     })
-  }
-
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    const { min, max, timeslots, step } = nextProps
-    this.slotMetrics = this.slotMetrics.update({ min, max, timeslots, step })
+    this.ref = React.createRef()
   }
 
   renderSlot = (value, idx) => {
@@ -36,10 +32,19 @@ export default class TimeGutter extends Component {
   }
 
   render() {
-    const { resource, components, getters } = this.props
+    const {
+      resource,
+      components,
+      getters,
+      min,
+      max,
+      timeslots,
+      step,
+    } = this.props
+    this.slotMetrics = this.slotMetrics.update({ min, max, timeslots, step })
 
     return (
-      <div className="rbc-time-gutter rbc-time-column">
+      <div ref={this.ref} className="rbc-time-gutter rbc-time-column">
         {this.slotMetrics.groups.map((grp, idx) => {
           return (
             <TimeSlotGroup

--- a/src/addons/dragAndDrop/DragAndDropContext.js
+++ b/src/addons/dragAndDrop/DragAndDropContext.js
@@ -1,0 +1,14 @@
+import React from 'react'
+
+const DragAndDropContext = React.createContext({
+  onStart: null,
+  onEnd: null,
+  onBeginAction: null,
+  onDropFromOutside: null,
+  dragFromOutsideItem: null,
+  draggableAccessor: null,
+  resizableAccessor: null,
+  dragAndDropAction: null,
+})
+
+export default DragAndDropContext

--- a/src/addons/dragAndDrop/EventContainerWrapper.js
+++ b/src/addons/dragAndDrop/EventContainerWrapper.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import * as dates from '../../utils/dates'
-import { findDOMNode } from 'react-dom'
 
 import Selection, {
   getBoundsForNode,
@@ -31,6 +30,7 @@ class EventContainerWrapper extends React.Component {
   constructor(...args) {
     super(...args)
     this.state = {}
+    this.ref = React.createRef()
   }
 
   componentDidMount() {
@@ -122,7 +122,10 @@ class EventContainerWrapper extends React.Component {
   }
 
   _selectable = () => {
-    let node = findDOMNode(this)
+    let node = this.ref.current
+    if (!node) {
+      return false
+    }
     let isBeingDragged = false
     let selector = (this._selector = new Selection(() =>
       node.closest('.rbc-time-view')
@@ -240,6 +243,7 @@ class EventContainerWrapper extends React.Component {
     else label = localizer.format({ start, end }, format)
 
     return React.cloneElement(children, {
+      ref: this.ref,
       children: (
         <React.Fragment>
           {events}

--- a/src/addons/dragAndDrop/EventContainerWrapper.js
+++ b/src/addons/dragAndDrop/EventContainerWrapper.js
@@ -10,6 +10,7 @@ import Selection, {
 import TimeGridEvent from '../../TimeGridEvent'
 import { dragAccessors } from './common'
 import NoopWrapper from '../../NoopWrapper'
+import { DragAndDropContext } from './withDragAndDrop'
 
 const pointInColumn = (bounds, { x, y }) => {
   const { left, right, top } = bounds
@@ -25,17 +26,6 @@ class EventContainerWrapper extends React.Component {
     localizer: PropTypes.object.isRequired,
     slotMetrics: PropTypes.object.isRequired,
     resource: PropTypes.any,
-  }
-
-  static contextTypes = {
-    draggable: PropTypes.shape({
-      onStart: PropTypes.func,
-      onEnd: PropTypes.func,
-      onDropFromOutside: PropTypes.func,
-      onBeginAction: PropTypes.func,
-      dragAndDropAction: PropTypes.object,
-      dragFromOutsideItem: PropTypes.func,
-    }),
   }
 
   constructor(...args) {
@@ -221,55 +211,63 @@ class EventContainerWrapper extends React.Component {
   }
 
   render() {
-    const {
-      children,
-      accessors,
-      components,
-      getters,
-      slotMetrics,
-      localizer,
-    } = this.props
+    return (
+      <DragAndDropContext.Consumer>
+        {context => {
+          this.context = context
+          const {
+            children,
+            accessors,
+            components,
+            getters,
+            slotMetrics,
+            localizer,
+          } = this.props
 
-    let { event, top, height } = this.state
+          let { event, top, height } = this.state
 
-    if (!event) return children
+          if (!event) return children
 
-    const events = children.props.children
-    const { start, end } = event
+          const events = children.props.children
+          const { start, end } = event
 
-    let label
-    let format = 'eventTimeRangeFormat'
+          let label
+          let format = 'eventTimeRangeFormat'
 
-    const startsBeforeDay = slotMetrics.startsBeforeDay(start)
-    const startsAfterDay = slotMetrics.startsAfterDay(end)
+          const startsBeforeDay = slotMetrics.startsBeforeDay(start)
+          const startsAfterDay = slotMetrics.startsAfterDay(end)
 
-    if (startsBeforeDay) format = 'eventTimeRangeEndFormat'
-    else if (startsAfterDay) format = 'eventTimeRangeStartFormat'
+          if (startsBeforeDay) format = 'eventTimeRangeEndFormat'
+          else if (startsAfterDay) format = 'eventTimeRangeStartFormat'
 
-    if (startsBeforeDay && startsAfterDay) label = localizer.messages.allDay
-    else label = localizer.format({ start, end }, format)
+          if (startsBeforeDay && startsAfterDay)
+            label = localizer.messages.allDay
+          else label = localizer.format({ start, end }, format)
 
-    return React.cloneElement(children, {
-      children: (
-        <React.Fragment>
-          {events}
+          return React.cloneElement(children, {
+            children: (
+              <React.Fragment>
+                {events}
 
-          {event && (
-            <TimeGridEvent
-              event={event}
-              label={label}
-              className="rbc-addons-dnd-drag-preview"
-              style={{ top, height, width: 100 }}
-              getters={getters}
-              components={{ ...components, eventWrapper: NoopWrapper }}
-              accessors={{ ...accessors, ...dragAccessors }}
-              continuesEarlier={startsBeforeDay}
-              continuesLater={startsAfterDay}
-            />
-          )}
-        </React.Fragment>
-      ),
-    })
+                {event && (
+                  <TimeGridEvent
+                    event={event}
+                    label={label}
+                    className="rbc-addons-dnd-drag-preview"
+                    style={{ top, height, width: 100 }}
+                    getters={getters}
+                    components={{ ...components, eventWrapper: NoopWrapper }}
+                    accessors={{ ...accessors, ...dragAccessors }}
+                    continuesEarlier={startsBeforeDay}
+                    continuesLater={startsAfterDay}
+                  />
+                )}
+              </React.Fragment>
+            ),
+          })
+        }}
+      </DragAndDropContext.Consumer>
+    )
   }
 }
 

--- a/src/addons/dragAndDrop/EventContainerWrapper.js
+++ b/src/addons/dragAndDrop/EventContainerWrapper.js
@@ -10,7 +10,7 @@ import Selection, {
 import TimeGridEvent from '../../TimeGridEvent'
 import { dragAccessors } from './common'
 import NoopWrapper from '../../NoopWrapper'
-import { DragAndDropContext } from './withDragAndDrop'
+import DragAndDropContext from './DragAndDropContext'
 
 const pointInColumn = (bounds, { x, y }) => {
   const { left, right, top } = bounds
@@ -211,66 +211,59 @@ class EventContainerWrapper extends React.Component {
   }
 
   render() {
-    return (
-      <DragAndDropContext.Consumer>
-        {context => {
-          this.context = context
-          const {
-            children,
-            accessors,
-            components,
-            getters,
-            slotMetrics,
-            localizer,
-          } = this.props
+    const {
+      children,
+      accessors,
+      components,
+      getters,
+      slotMetrics,
+      localizer,
+    } = this.props
 
-          let { event, top, height } = this.state
+    let { event, top, height } = this.state
 
-          if (!event) return children
+    if (!event) return children
 
-          const events = children.props.children
-          const { start, end } = event
+    const events = children.props.children
+    const { start, end } = event
 
-          let label
-          let format = 'eventTimeRangeFormat'
+    let label
+    let format = 'eventTimeRangeFormat'
 
-          const startsBeforeDay = slotMetrics.startsBeforeDay(start)
-          const startsAfterDay = slotMetrics.startsAfterDay(end)
+    const startsBeforeDay = slotMetrics.startsBeforeDay(start)
+    const startsAfterDay = slotMetrics.startsAfterDay(end)
 
-          if (startsBeforeDay) format = 'eventTimeRangeEndFormat'
-          else if (startsAfterDay) format = 'eventTimeRangeStartFormat'
+    if (startsBeforeDay) format = 'eventTimeRangeEndFormat'
+    else if (startsAfterDay) format = 'eventTimeRangeStartFormat'
 
-          if (startsBeforeDay && startsAfterDay)
-            label = localizer.messages.allDay
-          else label = localizer.format({ start, end }, format)
+    if (startsBeforeDay && startsAfterDay) label = localizer.messages.allDay
+    else label = localizer.format({ start, end }, format)
 
-          return React.cloneElement(children, {
-            children: (
-              <React.Fragment>
-                {events}
+    return React.cloneElement(children, {
+      children: (
+        <React.Fragment>
+          {events}
 
-                {event && (
-                  <TimeGridEvent
-                    event={event}
-                    label={label}
-                    className="rbc-addons-dnd-drag-preview"
-                    style={{ top, height, width: 100 }}
-                    getters={getters}
-                    components={{ ...components, eventWrapper: NoopWrapper }}
-                    accessors={{ ...accessors, ...dragAccessors }}
-                    continuesEarlier={startsBeforeDay}
-                    continuesLater={startsAfterDay}
-                  />
-                )}
-              </React.Fragment>
-            ),
-          })
-        }}
-      </DragAndDropContext.Consumer>
-    )
+          {event && (
+            <TimeGridEvent
+              event={event}
+              label={label}
+              className="rbc-addons-dnd-drag-preview"
+              style={{ top, height, width: 100 }}
+              getters={getters}
+              components={{ ...components, eventWrapper: NoopWrapper }}
+              accessors={{ ...accessors, ...dragAccessors }}
+              continuesEarlier={startsBeforeDay}
+              continuesLater={startsAfterDay}
+            />
+          )}
+        </React.Fragment>
+      ),
+    })
   }
 }
 
 EventContainerWrapper.propTypes = propTypes
+EventContainerWrapper.contextType = DragAndDropContext
 
 export default EventContainerWrapper

--- a/src/addons/dragAndDrop/EventWrapper.js
+++ b/src/addons/dragAndDrop/EventWrapper.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import clsx from 'clsx'
 import { accessor as get } from '../../utils/accessors'
-import { DragAndDropContext } from './withDragAndDrop'
+import DragAndDropContext from './DragAndDropContext'
 
 class EventWrapper extends React.Component {
   static propTypes = {
@@ -57,113 +57,107 @@ class EventWrapper extends React.Component {
   }
 
   render() {
-    return (
-      <DragAndDropContext.Consumer>
-        {context => {
-          this.context = context
+    const { event, type, continuesPrior, continuesAfter } = this.props
 
-          const { event, type, continuesPrior, continuesAfter } = this.props
+    let { children } = this.props
 
-          let { children } = this.props
+    if (event.__isPreview)
+      return React.cloneElement(children, {
+        className: clsx(
+          children.props.className,
+          'rbc-addons-dnd-drag-preview'
+        ),
+      })
 
-          if (event.__isPreview)
-            return React.cloneElement(children, {
-              className: clsx(
-                children.props.className,
-                'rbc-addons-dnd-drag-preview'
-              ),
-            })
+    const { draggable } = this.context
+    const { draggableAccessor, resizableAccessor } = draggable
 
-          const { draggable } = this.context
-          const { draggableAccessor, resizableAccessor } = draggable
+    const isDraggable = draggableAccessor
+      ? !!get(event, draggableAccessor)
+      : true
 
-          const isDraggable = draggableAccessor
-            ? !!get(event, draggableAccessor)
-            : true
+    /* Event is not draggable, no need to wrap it */
+    if (!isDraggable) {
+      return children
+    }
 
-          /* Event is not draggable, no need to wrap it */
-          if (!isDraggable) {
-            return children
-          }
+    /*
+     * The resizability of events depends on whether they are
+     * allDay events and how they are displayed.
+     *
+     * 1. If the event is being shown in an event row (because
+     * it is an allDay event shown in the header row or because as
+     * in month view the view is showing all events as rows) then we
+     * allow east-west resizing.
+     *
+     * 2. Otherwise the event is being displayed
+     * normally, we can drag it north-south to resize the times.
+     *
+     * See `DropWrappers` for handling of the drop of such events.
+     *
+     * Notwithstanding the above, we never show drag anchors for
+     * events which continue beyond current component. This happens
+     * in the middle of events when showMultiDay is true, and to
+     * events at the edges of the calendar's min/max location.
+     */
+    const isResizable = resizableAccessor
+      ? !!get(event, resizableAccessor)
+      : true
 
-          /*
-           * The resizability of events depends on whether they are
-           * allDay events and how they are displayed.
-           *
-           * 1. If the event is being shown in an event row (because
-           * it is an allDay event shown in the header row or because as
-           * in month view the view is showing all events as rows) then we
-           * allow east-west resizing.
-           *
-           * 2. Otherwise the event is being displayed
-           * normally, we can drag it north-south to resize the times.
-           *
-           * See `DropWrappers` for handling of the drop of such events.
-           *
-           * Notwithstanding the above, we never show drag anchors for
-           * events which continue beyond current component. This happens
-           * in the middle of events when showMultiDay is true, and to
-           * events at the edges of the calendar's min/max location.
-           */
-          const isResizable = resizableAccessor
-            ? !!get(event, resizableAccessor)
-            : true
+    if (isResizable || isDraggable) {
+      /*
+       * props.children is the singular <Event> component.
+       * BigCalendar positions the Event abolutely and we
+       * need the anchors to be part of that positioning.
+       * So we insert the anchors inside the Event's children
+       * rather than wrap the Event here as the latter approach
+       * would lose the positioning.
+       */
+      const newProps = {
+        onMouseDown: this.handleStartDragging,
+        onTouchStart: this.handleStartDragging,
+      }
 
-          if (isResizable || isDraggable) {
-            /*
-             * props.children is the singular <Event> component.
-             * BigCalendar positions the Event abolutely and we
-             * need the anchors to be part of that positioning.
-             * So we insert the anchors inside the Event's children
-             * rather than wrap the Event here as the latter approach
-             * would lose the positioning.
-             */
-            const newProps = {
-              onMouseDown: this.handleStartDragging,
-              onTouchStart: this.handleStartDragging,
-            }
+      if (isResizable) {
+        // replace original event child with anchor-embellished child
+        let StartAnchor = null
+        let EndAnchor = null
 
-            if (isResizable) {
-              // replace original event child with anchor-embellished child
-              let StartAnchor = null
-              let EndAnchor = null
+        if (type === 'date') {
+          StartAnchor = !continuesPrior && this.renderAnchor('Left')
+          EndAnchor = !continuesAfter && this.renderAnchor('Right')
+        } else {
+          StartAnchor = !continuesPrior && this.renderAnchor('Up')
+          EndAnchor = !continuesAfter && this.renderAnchor('Down')
+        }
 
-              if (type === 'date') {
-                StartAnchor = !continuesPrior && this.renderAnchor('Left')
-                EndAnchor = !continuesAfter && this.renderAnchor('Right')
-              } else {
-                StartAnchor = !continuesPrior && this.renderAnchor('Up')
-                EndAnchor = !continuesAfter && this.renderAnchor('Down')
-              }
+        newProps.children = (
+          <div className="rbc-addons-dnd-resizable">
+            {StartAnchor}
+            {children.props.children}
+            {EndAnchor}
+          </div>
+        )
+      }
 
-              newProps.children = (
-                <div className="rbc-addons-dnd-resizable">
-                  {StartAnchor}
-                  {children.props.children}
-                  {EndAnchor}
-                </div>
-              )
-            }
+      if (
+        draggable.dragAndDropAction.interacting && // if an event is being dragged right now
+        draggable.dragAndDropAction.event === event // and it's the current event
+      ) {
+        // add a new class to it
+        newProps.className = clsx(
+          children.props.className,
+          'rbc-addons-dnd-dragged-event'
+        )
+      }
 
-            if (
-              draggable.dragAndDropAction.interacting && // if an event is being dragged right now
-              draggable.dragAndDropAction.event === event // and it's the current event
-            ) {
-              // add a new class to it
-              newProps.className = clsx(
-                children.props.className,
-                'rbc-addons-dnd-dragged-event'
-              )
-            }
+      children = React.cloneElement(children, newProps)
+    }
 
-            children = React.cloneElement(children, newProps)
-          }
-
-          return children
-        }}
-      </DragAndDropContext.Consumer>
-    )
+    return children
   }
 }
+
+EventWrapper.contextType = DragAndDropContext
 
 export default EventWrapper

--- a/src/addons/dragAndDrop/EventWrapper.js
+++ b/src/addons/dragAndDrop/EventWrapper.js
@@ -1,21 +1,10 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import clsx from 'clsx'
-import { accessor } from '../../utils/propTypes'
 import { accessor as get } from '../../utils/accessors'
+import { DragAndDropContext } from './withDragAndDrop'
 
 class EventWrapper extends React.Component {
-  static contextTypes = {
-    draggable: PropTypes.shape({
-      onStart: PropTypes.func,
-      onEnd: PropTypes.func,
-      onBeginAction: PropTypes.func,
-      draggableAccessor: accessor,
-      resizableAccessor: accessor,
-      dragAndDropAction: PropTypes.object,
-    }),
-  }
-
   static propTypes = {
     type: PropTypes.oneOf(['date', 'time']),
     event: PropTypes.object.isRequired,
@@ -68,104 +57,112 @@ class EventWrapper extends React.Component {
   }
 
   render() {
-    const { event, type, continuesPrior, continuesAfter } = this.props
+    return (
+      <DragAndDropContext.Consumer>
+        {context => {
+          this.context = context
 
-    let { children } = this.props
+          const { event, type, continuesPrior, continuesAfter } = this.props
 
-    if (event.__isPreview)
-      return React.cloneElement(children, {
-        className: clsx(
-          children.props.className,
-          'rbc-addons-dnd-drag-preview'
-        ),
-      })
+          let { children } = this.props
 
-    const { draggable } = this.context
-    const { draggableAccessor, resizableAccessor } = draggable
+          if (event.__isPreview)
+            return React.cloneElement(children, {
+              className: clsx(
+                children.props.className,
+                'rbc-addons-dnd-drag-preview'
+              ),
+            })
 
-    const isDraggable = draggableAccessor
-      ? !!get(event, draggableAccessor)
-      : true
+          const { draggable } = this.context
+          const { draggableAccessor, resizableAccessor } = draggable
 
-    /* Event is not draggable, no need to wrap it */
-    if (!isDraggable) {
-      return children
-    }
+          const isDraggable = draggableAccessor
+            ? !!get(event, draggableAccessor)
+            : true
 
-    /*
-     * The resizability of events depends on whether they are
-     * allDay events and how they are displayed.
-     *
-     * 1. If the event is being shown in an event row (because
-     * it is an allDay event shown in the header row or because as
-     * in month view the view is showing all events as rows) then we
-     * allow east-west resizing.
-     *
-     * 2. Otherwise the event is being displayed
-     * normally, we can drag it north-south to resize the times.
-     *
-     * See `DropWrappers` for handling of the drop of such events.
-     *
-     * Notwithstanding the above, we never show drag anchors for
-     * events which continue beyond current component. This happens
-     * in the middle of events when showMultiDay is true, and to
-     * events at the edges of the calendar's min/max location.
-     */
-    const isResizable = resizableAccessor
-      ? !!get(event, resizableAccessor)
-      : true
+          /* Event is not draggable, no need to wrap it */
+          if (!isDraggable) {
+            return children
+          }
 
-    if (isResizable || isDraggable) {
-      /*
-       * props.children is the singular <Event> component.
-       * BigCalendar positions the Event abolutely and we
-       * need the anchors to be part of that positioning.
-       * So we insert the anchors inside the Event's children
-       * rather than wrap the Event here as the latter approach
-       * would lose the positioning.
-       */
-      const newProps = {
-        onMouseDown: this.handleStartDragging,
-        onTouchStart: this.handleStartDragging,
-      }
+          /*
+           * The resizability of events depends on whether they are
+           * allDay events and how they are displayed.
+           *
+           * 1. If the event is being shown in an event row (because
+           * it is an allDay event shown in the header row or because as
+           * in month view the view is showing all events as rows) then we
+           * allow east-west resizing.
+           *
+           * 2. Otherwise the event is being displayed
+           * normally, we can drag it north-south to resize the times.
+           *
+           * See `DropWrappers` for handling of the drop of such events.
+           *
+           * Notwithstanding the above, we never show drag anchors for
+           * events which continue beyond current component. This happens
+           * in the middle of events when showMultiDay is true, and to
+           * events at the edges of the calendar's min/max location.
+           */
+          const isResizable = resizableAccessor
+            ? !!get(event, resizableAccessor)
+            : true
 
-      if (isResizable) {
-        // replace original event child with anchor-embellished child
-        let StartAnchor = null
-        let EndAnchor = null
+          if (isResizable || isDraggable) {
+            /*
+             * props.children is the singular <Event> component.
+             * BigCalendar positions the Event abolutely and we
+             * need the anchors to be part of that positioning.
+             * So we insert the anchors inside the Event's children
+             * rather than wrap the Event here as the latter approach
+             * would lose the positioning.
+             */
+            const newProps = {
+              onMouseDown: this.handleStartDragging,
+              onTouchStart: this.handleStartDragging,
+            }
 
-        if (type === 'date') {
-          StartAnchor = !continuesPrior && this.renderAnchor('Left')
-          EndAnchor = !continuesAfter && this.renderAnchor('Right')
-        } else {
-          StartAnchor = !continuesPrior && this.renderAnchor('Up')
-          EndAnchor = !continuesAfter && this.renderAnchor('Down')
-        }
+            if (isResizable) {
+              // replace original event child with anchor-embellished child
+              let StartAnchor = null
+              let EndAnchor = null
 
-        newProps.children = (
-          <div className="rbc-addons-dnd-resizable">
-            {StartAnchor}
-            {children.props.children}
-            {EndAnchor}
-          </div>
-        )
-      }
+              if (type === 'date') {
+                StartAnchor = !continuesPrior && this.renderAnchor('Left')
+                EndAnchor = !continuesAfter && this.renderAnchor('Right')
+              } else {
+                StartAnchor = !continuesPrior && this.renderAnchor('Up')
+                EndAnchor = !continuesAfter && this.renderAnchor('Down')
+              }
 
-      if (
-        draggable.dragAndDropAction.interacting && // if an event is being dragged right now
-        draggable.dragAndDropAction.event === event // and it's the current event
-      ) {
-        // add a new class to it
-        newProps.className = clsx(
-          children.props.className,
-          'rbc-addons-dnd-dragged-event'
-        )
-      }
+              newProps.children = (
+                <div className="rbc-addons-dnd-resizable">
+                  {StartAnchor}
+                  {children.props.children}
+                  {EndAnchor}
+                </div>
+              )
+            }
 
-      children = React.cloneElement(children, newProps)
-    }
+            if (
+              draggable.dragAndDropAction.interacting && // if an event is being dragged right now
+              draggable.dragAndDropAction.event === event // and it's the current event
+            ) {
+              // add a new class to it
+              newProps.className = clsx(
+                children.props.className,
+                'rbc-addons-dnd-dragged-event'
+              )
+            }
 
-    return children
+            children = React.cloneElement(children, newProps)
+          }
+
+          return children
+        }}
+      </DragAndDropContext.Consumer>
+    )
   }
 }
 

--- a/src/addons/dragAndDrop/WeekWrapper.js
+++ b/src/addons/dragAndDrop/WeekWrapper.js
@@ -7,6 +7,7 @@ import { eventSegments } from '../../utils/eventLevels'
 import Selection, { getBoundsForNode } from '../../Selection'
 import EventRow from '../../EventRow'
 import { dragAccessors } from './common'
+import { DragAndDropContext } from './withDragAndDrop'
 
 const propTypes = {}
 
@@ -29,17 +30,6 @@ class WeekWrapper extends React.Component {
     getters: PropTypes.object.isRequired,
     components: PropTypes.object.isRequired,
     resourceId: PropTypes.any,
-  }
-
-  static contextTypes = {
-    draggable: PropTypes.shape({
-      onStart: PropTypes.func,
-      onEnd: PropTypes.func,
-      dragAndDropAction: PropTypes.object,
-      onDropFromOutside: PropTypes.func,
-      onBeginAction: PropTypes.func,
-      dragFromOutsideItem: PropTypes.func,
-    }),
   }
 
   constructor(...args) {
@@ -268,27 +258,34 @@ class WeekWrapper extends React.Component {
   }
 
   render() {
-    const { children, accessors } = this.props
-
-    let { segment } = this.state
-
     return (
-      <div ref={this.ref} className="rbc-addons-dnd-row-body">
-        {children}
+      <DragAndDropContext.Consumer>
+        {context => {
+          this.context = context
+          const { children, accessors } = this.props
 
-        {segment && (
-          <EventRow
-            {...this.props}
-            selected={null}
-            className="rbc-addons-dnd-drag-row"
-            segments={[segment]}
-            accessors={{
-              ...accessors,
-              ...dragAccessors,
-            }}
-          />
-        )}
-      </div>
+          let { segment } = this.state
+
+          return (
+            <div ref={this.ref} className="rbc-addons-dnd-row-body">
+              {children}
+
+              {segment && (
+                <EventRow
+                  {...this.props}
+                  selected={null}
+                  className="rbc-addons-dnd-drag-row"
+                  segments={[segment]}
+                  accessors={{
+                    ...accessors,
+                    ...dragAccessors,
+                  }}
+                />
+              )}
+            </div>
+          )
+        }}
+      </DragAndDropContext.Consumer>
     )
   }
 }

--- a/src/addons/dragAndDrop/WeekWrapper.js
+++ b/src/addons/dragAndDrop/WeekWrapper.js
@@ -7,7 +7,7 @@ import { eventSegments } from '../../utils/eventLevels'
 import Selection, { getBoundsForNode } from '../../Selection'
 import EventRow from '../../EventRow'
 import { dragAccessors } from './common'
-import { DragAndDropContext } from './withDragAndDrop'
+import DragAndDropContext from './DragAndDropContext'
 
 const propTypes = {}
 
@@ -258,38 +258,32 @@ class WeekWrapper extends React.Component {
   }
 
   render() {
+    const { children, accessors } = this.props
+
+    let { segment } = this.state
+
     return (
-      <DragAndDropContext.Consumer>
-        {context => {
-          this.context = context
-          const { children, accessors } = this.props
+      <div ref={this.ref} className="rbc-addons-dnd-row-body">
+        {children}
 
-          let { segment } = this.state
-
-          return (
-            <div ref={this.ref} className="rbc-addons-dnd-row-body">
-              {children}
-
-              {segment && (
-                <EventRow
-                  {...this.props}
-                  selected={null}
-                  className="rbc-addons-dnd-drag-row"
-                  segments={[segment]}
-                  accessors={{
-                    ...accessors,
-                    ...dragAccessors,
-                  }}
-                />
-              )}
-            </div>
-          )
-        }}
-      </DragAndDropContext.Consumer>
+        {segment && (
+          <EventRow
+            {...this.props}
+            selected={null}
+            className="rbc-addons-dnd-drag-row"
+            segments={[segment]}
+            accessors={{
+              ...accessors,
+              ...dragAccessors,
+            }}
+          />
+        )}
+      </div>
     )
   }
 }
 
 WeekWrapper.propTypes = propTypes
+WeekWrapper.contextType = DragAndDropContext
 
 export default WeekWrapper

--- a/src/addons/dragAndDrop/WeekWrapper.js
+++ b/src/addons/dragAndDrop/WeekWrapper.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import * as dates from '../../utils/dates'
 import { getSlotAtX, pointInBox } from '../../utils/selection'
-import { findDOMNode } from 'react-dom'
 
 import { eventSegments } from '../../utils/eventLevels'
 import Selection, { getBoundsForNode } from '../../Selection'
@@ -46,6 +45,7 @@ class WeekWrapper extends React.Component {
   constructor(...args) {
     super(...args)
     this.state = {}
+    this.ref = React.createRef()
   }
 
   componentDidMount() {
@@ -189,7 +189,7 @@ class WeekWrapper extends React.Component {
   }
 
   _selectable = () => {
-    let node = findDOMNode(this).closest('.rbc-month-row, .rbc-allday-cell')
+    let node = this.ref.current.closest('.rbc-month-row, .rbc-allday-cell')
     let container = node.closest('.rbc-month-view, .rbc-time-view')
 
     let selector = (this._selector = new Selection(() => container))
@@ -273,7 +273,7 @@ class WeekWrapper extends React.Component {
     let { segment } = this.state
 
     return (
-      <div className="rbc-addons-dnd-row-body">
+      <div ref={this.ref} className="rbc-addons-dnd-row-body">
         {children}
 
         {segment && (

--- a/src/addons/dragAndDrop/withDragAndDrop.js
+++ b/src/addons/dragAndDrop/withDragAndDrop.js
@@ -7,17 +7,7 @@ import EventWrapper from './EventWrapper'
 import EventContainerWrapper from './EventContainerWrapper'
 import WeekWrapper from './WeekWrapper'
 import { mergeComponents } from './common'
-
-export const DragAndDropContext = React.createContext({
-  onStart: null,
-  onEnd: null,
-  onBeginAction: null,
-  onDropFromOutside: null,
-  dragFromOutsideItem: null,
-  draggableAccessor: null,
-  resizableAccessor: null,
-  dragAndDropAction: null,
-})
+import DragAndDropContext from './DragAndDropContext'
 
 /**
  * Creates a higher-order component (HOC) supporting drag & drop and optionally resizing

--- a/src/addons/dragAndDrop/withDragAndDrop.js
+++ b/src/addons/dragAndDrop/withDragAndDrop.js
@@ -8,6 +8,17 @@ import EventContainerWrapper from './EventContainerWrapper'
 import WeekWrapper from './WeekWrapper'
 import { mergeComponents } from './common'
 
+export const DragAndDropContext = React.createContext({
+  onStart: null,
+  onEnd: null,
+  onBeginAction: null,
+  onDropFromOutside: null,
+  dragFromOutsideItem: null,
+  draggableAccessor: null,
+  resizableAccessor: null,
+  dragAndDropAction: null,
+})
+
 /**
  * Creates a higher-order component (HOC) supporting drag & drop and optionally resizing
  * of events:
@@ -92,23 +103,6 @@ export default function withDragAndDrop(Calendar) {
       step: 30,
     }
 
-    static contextTypes = {
-      dragDropManager: PropTypes.object,
-    }
-
-    static childContextTypes = {
-      draggable: PropTypes.shape({
-        onStart: PropTypes.func,
-        onEnd: PropTypes.func,
-        onBeginAction: PropTypes.func,
-        onDropFromOutside: PropTypes.func,
-        dragFromOutsideItem: PropTypes.func,
-        draggableAccessor: accessor,
-        resizableAccessor: accessor,
-        dragAndDropAction: PropTypes.object,
-      }),
-    }
-
     constructor(...args) {
       super(...args)
 
@@ -123,7 +117,7 @@ export default function withDragAndDrop(Calendar) {
       this.state = { interacting: false }
     }
 
-    getChildContext() {
+    getDragAndDropContext() {
       return {
         draggable: {
           onStart: this.handleInteractionStart,
@@ -195,11 +189,13 @@ export default function withDragAndDrop(Calendar) {
       )
 
       return (
-        <Calendar
-          {...props}
-          elementProps={elementPropsWithDropFromOutside}
-          components={this.components}
-        />
+        <DragAndDropContext.Provider value={this.getDragAndDropContext()}>
+          <Calendar
+            {...props}
+            elementProps={elementPropsWithDropFromOutside}
+            components={this.components}
+          />
+        </DragAndDropContext.Provider>
       )
     }
   }


### PR DESCRIPTION
In reference to #1200 I've started on removing references to `findDOMNode()`. 

I've gotten ridd of all of them except one in `EventContainerWrapper`, which needs a larger rethink due to refs not working quite the same as `findDOMNode()` with components that use `React.cloneElement()` in `render()`.

I've also converted the draggable context from the legacy format to using `React.createContext()`. A larger rewrite would probably be necessary to bring this part of the code base more in line with modern React, but this works for now.

Finally, I've replaced `UNSAFE_componentWillReceiveProps()` with `componentDidUpdate()` and `getDerivedStateFromProps()` equivalents.
