### PR TITLE
Fixed a bug that the height of the column is broken when displayed in IE11

### DIFF
--- a/src/sass/time-column.scss
+++ b/src/sass/time-column.scss
@@ -5,6 +5,8 @@
   flex-direction: column;
   min-height: 100%;
 
+  height: 100%; // ie-fix
+
   .rbc-timeslot-group {
     flex: 1;
   }


### PR DESCRIPTION
## What
I found a bug that shrinks the height of the TimeColumn when viewed in IE11.
Added `height: 100%;` as well as other parts, so that it won't collapse on IE11.

↓ Before
<img width="688" alt="スクリーンショット 2020-11-02 14 09 08" src="https://user-images.githubusercontent.com/3971271/97832172-79357f80-1d15-11eb-8629-4815bbd8a15d.png">

↓ After
<img width="688" alt="スクリーンショット 2020-11-02 14 09 50" src="https://user-images.githubusercontent.com/3971271/97832175-7a66ac80-1d15-11eb-8579-fa5d9cf2d5d9.png">
