### PR TITLE
Preserve time on horizontal resizing

### DIFF
--- a/src/addons/dragAndDrop/WeekWrapper.js
+++ b/src/addons/dragAndDrop/WeekWrapper.js
@@ -138,6 +138,8 @@ class WeekWrapper extends React.Component {
     const { accessors, slotMetrics: metrics } = this.props
 
     let { start, end } = eventTimes(event, accessors)
+    let originalStart = start
+    let originalEnd = end
 
     let rowBox = getBoundsForNode(node)
     let cursorInRow = pointInBox(rowBox, point)
@@ -145,13 +147,8 @@ class WeekWrapper extends React.Component {
     if (direction === 'RIGHT') {
       if (cursorInRow) {
         if (metrics.last < start) return this.reset()
-        // add min
-        end = dates.add(
-          metrics.getDateForSlot(
-            getSlotAtX(rowBox, point.x, false, metrics.slots)
-          ),
-          1,
-          'day'
+        end = metrics.getDateForSlot(
+          getSlotAtX(rowBox, point.x, false, metrics.slots)
         )
       } else if (
         dates.inRange(start, metrics.first, metrics.last) ||
@@ -162,8 +159,10 @@ class WeekWrapper extends React.Component {
         this.setState({ segment: null })
         return
       }
-
-      end = dates.max(end, dates.add(start, 1, 'day'))
+      end = dates.merge(end, accessors.end(event))
+      if (dates.lt(end, start)) {
+        end = originalEnd
+      }
     } else if (direction === 'LEFT') {
       // inbetween Row
       if (cursorInRow) {
@@ -181,8 +180,10 @@ class WeekWrapper extends React.Component {
         this.reset()
         return
       }
-
-      start = dates.min(dates.add(end, -1, 'day'), start)
+      start = dates.merge(start, accessors.start(event))
+      if (dates.gt(start, end)) {
+        start = originalStart
+      }
     }
 
     this.update(event, start, end)


### PR DESCRIPTION
When an event is resized horizontally (e.g. on the Month
View), keep the time of the event the same and only change
the date.

This also fixes the bug where you cannot resize an event to
a single day because the `dates.max` or `dates.min` would
force the event to occur at least 1 day after the
`start` or `end` respectively.