### PR TITLE
Fix bug with resize segments not being removed

### DIFF
--- a/src/addons/dragAndDrop/WeekWrapper.js
+++ b/src/addons/dragAndDrop/WeekWrapper.js
@@ -218,8 +218,13 @@ class WeekWrapper extends React.Component {
     selector.on('select', point => {
       const bounds = getBoundsForNode(node)
 
-      if (!this.state.segment || !pointInBox(bounds, point)) return
-      this.handleInteractionEnd()
+      if (!this.state.segment) return
+
+      if (!pointInBox(bounds, point)) {
+        this.reset()
+      } else {
+        this.handleInteractionEnd()
+      }
     })
 
     selector.on('dropFromOutside', point => {


### PR DESCRIPTION
When an event is resized to span multiple rows, the preview
segments in the non-ending row would not be removed because
the `!pointInBox` would cause an early return.

This commit removes segments when the resize action finishes.

`onEventResize` is set to an empty function so we would expect the event to revert back to normal when the resize action ends.
**Bug**:
The preview segment in the 3rd and 4th rows persist after the resizing is finished.
![Bug](https://user-images.githubusercontent.com/21178388/98411968-16115900-2045-11eb-8532-51e5994c5e73.gif)

**Updated**:
The preview segment in the 3rd and 4th rows are removed after resizing is finished. The event state is the same as the original state since `onEventResize` is an empty function.
![Updated](https://user-images.githubusercontent.com/21178388/98411971-1873b300-2045-11eb-92ec-09434f5afe04.gif)
