### PR TITLE
Update `ceil` function to handle midnight dates

### DIFF
--- a/src/addons/dragAndDrop/WeekWrapper.js
+++ b/src/addons/dragAndDrop/WeekWrapper.js
@@ -15,10 +15,6 @@ const eventTimes = (event, accessors) => {
   let start = accessors.start(event)
   let end = accessors.end(event)
 
-  const isZeroDuration =
-    dates.eq(start, end, 'minutes') && start.getMinutes() === 0
-  // make zero duration midnight events at least one day long
-  if (isZeroDuration) end = dates.add(end, 1, 'day')
   return { start, end }
 }
 

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -63,7 +63,7 @@ export function visibleDays(date, localizer) {
 export function ceil(date, unit) {
   let floor = dates.startOf(date, unit)
 
-  return dates.eq(floor, date) ? floor : dates.add(floor, 1, unit)
+  return dates.add(floor, 1, unit)
 }
 
 export function range(start, end, unit = 'day') {


### PR DESCRIPTION
This function now always adds a day to the end of the date.
Previously, this would make an exception for dates that
have a time of 12:00 AM and would return the current date,
rather than add an extra day.

This PR removes the exception where we treat dates that end at 12:00AM differently from any other time during the day. This caused a number of bugs:

**Bug 1**
In my example, I have a date that lasts Nov 10th 12:00AM to Nov 11th 12:00AM. When I try to resize to the right, it doesn't recognize changes until I span at least 2 date cells (to the 12th).
![bug](https://user-images.githubusercontent.com/21178388/98595646-430f7700-22a4-11eb-88c1-e24329332e2a.gif)

**Updated**
Now, resizing will recognize that I should add a date when I resize to the right.
![updated](https://user-images.githubusercontent.com/21178388/98595651-4571d100-22a4-11eb-915e-ab6e26e85d46.gif)

**Bug 2**
In my example, I have a date that has the same `start` and `end` of Nov 10th 12:00AM. When I resize to the right and try to resize to the original, it automatically add sets the `end` to the `start` + 1 day and I end up with an `end` of Nov 11th 12:00 AM when I try to resize to the original.
![bug2](https://user-images.githubusercontent.com/21178388/98595661-473b9480-22a4-11eb-88a4-bf99137872af.gif)

**Updated**
Now, I can resize to the original `end` time of Nov 10th 12:00AM.
![updated](https://user-images.githubusercontent.com/21178388/98595671-4acf1b80-22a4-11eb-80f0-fa51ffc70fab.gif)

**Bug 3**
In my example, I have a date that has the same `start` and `end` of Nov 10th 12:00AM. When I resize to the left, it automatically adds a day to the end and I end up changing both the `start` (to Nov 9th 12:00 AM, which is intended) and the `end` (to Nov 11th 12:00 AM, which is unintended)
![bug3](https://user-images.githubusercontent.com/21178388/98595681-4dca0c00-22a4-11eb-9595-68e68c0ea11e.gif)

**Updated**
Now, I only update the `start` and the end stays the same.
![updated](https://user-images.githubusercontent.com/21178388/98595685-4f93cf80-22a4-11eb-9be2-f47810404758.gif)

By making this update, this also causes events that end on 12:00AM to render differently. If I have an event that starts on the 10th at 12:00AM and ends on the 11th at 12:00AM, it used to only show up on the 10th date cell on the month view. With this update, it'll now render across the 10th and 11th date cell. In my opinion, the latter is more intuitive because if you wanted an even that lasted the entire day of the 10th, it should last from 12:00AM - 11:59 PM.