### PR TITLE
Revert "fix: a bug that the height of the column is broken when displ…

### DIFF
--- a/src/sass/time-column.scss
+++ b/src/sass/time-column.scss
@@ -5,8 +5,6 @@
   flex-direction: column;
   min-height: 100%;
 
-  height: 100%; // ie-fix
-
   .rbc-timeslot-group {
     flex: 1;
   }


### PR DESCRIPTION
…ayed in IE11 (#1789)"

This reverts commit a0538eeba1cc2e405a46b6fc1369ecce93739919.

This fix seems to have broken Day & Week view in almost all major browsers by messing up the event container height which throws off the absolute positioning of events. The fix for IE does seem like it warrants how broken things are. I'd suggest rolling back and finding a different fix forward. 

Bug here: https://github.com/jquense/react-big-calendar/issues/1802

Simple example with single event:

Before:
![](https://p-ZmF7dQ.b0.n0.cdn.getcloudapp.com/items/nOunxkdv/Image%202020-11-09%20at%203.44.52%20PM.png?v=cf06d13b343554f6ec9443142aea0ffa)

After:
![](https://p-ZmF7dQ.b0.n0.cdn.getcloudapp.com/items/o0umd6bn/Image%202020-11-09%20at%206.33.34%20PM.png?v=a3c96c7c0c68caccf730b63917d15456)