### PR TITLE
Add new Calendar prop: `componentProps`

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -720,6 +720,24 @@ class Calendar extends React.Component {
     }),
 
     /**
+     * Provide custom props to custom components.
+     * The name of the key should match the name of the
+     * custom component.
+     * ```jsx
+     * let componentProps = {
+     *   toolbar: {
+     *    customToolbarProp1: value1,
+     *    customToolbarProp2: value2,
+     *   }
+     * }
+     * <Calendar componentProps={componentProps} />
+     * ```
+     */
+    componentProps: PropTypes.shape({
+      toolbar: PropTypes.object,
+    }),
+
+    /**
      * String messages used throughout the component, override to provide localizations
      */
     messages: PropTypes.shape({
@@ -802,6 +820,7 @@ class Calendar extends React.Component {
     culture,
     messages = {},
     components = {},
+    componentProps = {},
     formats = {},
   }) {
     let names = viewNames(views)
@@ -825,6 +844,7 @@ class Calendar extends React.Component {
         weekWrapper: NoopWrapper,
         timeSlotWrapper: NoopWrapper,
       }),
+      componentProps: componentProps,
       accessors: {
         start: wrapAccessor(startAccessor),
         end: wrapAccessor(endAccessor),
@@ -889,6 +909,7 @@ class Calendar extends React.Component {
       formats: _1,
       messages: _2,
       culture: _3,
+      componentProps: _4,
       ...props
     } = this.props
 
@@ -898,6 +919,7 @@ class Calendar extends React.Component {
     const {
       accessors,
       components,
+      componentProps,
       getters,
       localizer,
       viewNames,
@@ -914,6 +936,7 @@ class Calendar extends React.Component {
       >
         {toolbar && (
           <CalToolbar
+            {...componentProps.toolbar}
             date={current}
             view={view}
             views={viewNames}


### PR DESCRIPTION
Supplying this prop allows users to pass custom props to
custom components. For now, this only allows custom props
to be passed to the Toolbar component.

A use case where this would come up, I want to add a custom Toolbar and I want to add some logic where a certain function is called when a button on the toolbar is pressed. The function will be passed down from the component rendering the Calendar and I would like Calendar to pass down the function to the Toolbar.