### PR TITLE
feat: Add new Calendar prop: `doShowMoreDrillDown`

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -388,6 +388,13 @@ class Calendar extends React.Component {
     views: componentViews,
 
     /**
+     * Determines whether the drill down should occur when clicking on the "+_x_ more" link.
+     * If `popup` is false, and `doShowMoreDrillDown` is true, the drill down will occur as usual.
+     * If `popup` is false, and `doShowMoreDrillDown` is false, the drill down will not occur and the `onShowMore` function will trigger.
+     */
+    doShowMoreDrillDown: PropTypes.bool,
+
+    /**
      * The string name of the destination view for drill-down actions, such
      * as clicking a date header, or the truncated events links. If
      * `getDrilldownView` is also specified it will be used instead.
@@ -764,6 +771,7 @@ class Calendar extends React.Component {
     step: 30,
     length: 30,
 
+    doShowMoreDrillDown: true,
     drilldownView: views.DAY,
 
     titleAccessor: 'title',
@@ -893,6 +901,7 @@ class Calendar extends React.Component {
       length,
       showMultiDayTimes,
       onShowMore,
+      doShowMoreDrillDown,
       components: _0,
       formats: _1,
       messages: _2,
@@ -950,6 +959,7 @@ class Calendar extends React.Component {
           onKeyPressEvent={this.handleKeyPressEvent}
           onSelectSlot={this.handleSelectSlot}
           onShowMore={onShowMore}
+          doShowMoreDrillDown={doShowMoreDrillDown}
         />
       </div>
     )

--- a/src/Month.js
+++ b/src/Month.js
@@ -268,7 +268,13 @@ class MonthView extends React.Component {
   }
 
   handleShowMore = (events, date, cell, slot, target) => {
-    const { popup, onDrillDown, onShowMore, getDrilldownView } = this.props
+    const {
+      popup,
+      onDrillDown,
+      onShowMore,
+      getDrilldownView,
+      doShowMoreDrillDown,
+    } = this.props
     //cancel any pending selections so only the event click goes through.
     this.clearSelection()
 
@@ -278,7 +284,7 @@ class MonthView extends React.Component {
       this.setState({
         overlay: { date, events, position, target },
       })
-    } else {
+    } else if (doShowMoreDrillDown) {
       notify(onDrillDown, [date, getDrilldownView(date) || views.DAY])
     }
 
@@ -345,6 +351,7 @@ MonthView.propTypes = {
   onKeyPressEvent: PropTypes.func,
   onShowMore: PropTypes.func,
   showAllEvents: PropTypes.bool,
+  doShowMoreDrillDown: PropTypes.bool,
   onDrillDown: PropTypes.func,
   getDrilldownView: PropTypes.func.isRequired,
 


### PR DESCRIPTION
Setting popup={false} doesn't let you control the onShowMore function properly as described in #1147  and #1527 , because it only goes to the drill down view. In order to fix this, I've added another prop called `doShowMoreDrillDown` that is defaulted to `true`. If true, it will do the same thing it currently does, and go to the drill down view. However, if you set this prop to false, it will instead just trigger the `onShowMore` function where you can then show your own customized popup as desired.
Fixes #1147 
Fixes #1527 