### PR TITLE
feat: add accessibility to month view

### DIFF
--- a/src/DateContentRow.js
+++ b/src/DateContentRow.js
@@ -153,7 +153,7 @@ class DateContentRow extends React.Component {
     }
 
     return (
-      <div className={className}>
+      <div className={className} role="rowgroup">
         <BackgroundCells
           date={date}
           getNow={getNow}
@@ -175,6 +175,7 @@ class DateContentRow extends React.Component {
             'rbc-row-content',
             showAllEvents && 'rbc-row-content-scrollable'
           )}
+          role="row"
         >
           {renderHeader && (
             <div className="rbc-row " ref={this.createHeadingRef}>

--- a/src/DateHeader.js
+++ b/src/DateHeader.js
@@ -7,7 +7,7 @@ const DateHeader = ({ label, drilldownView, onDrillDown }) => {
   }
 
   return (
-    <a href="#" onClick={onDrillDown}>
+    <a href="#" onClick={onDrillDown} role="cell">
       {label}
     </a>
   )

--- a/src/Header.js
+++ b/src/Header.js
@@ -2,7 +2,11 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 const Header = ({ label }) => {
-  return <span>{label}</span>
+  return (
+    <span role="columnheader" aria-sort="none">
+      {label}
+    </span>
+  )
 }
 
 Header.propTypes = {

--- a/src/Month.js
+++ b/src/Month.js
@@ -80,8 +80,12 @@ class MonthView extends React.Component {
     this._weekCount = weeks.length
 
     return (
-      <div className={clsx('rbc-month-view', className)}>
-        <div className="rbc-row rbc-month-header">
+      <div
+        className={clsx('rbc-month-view', className)}
+        role="table"
+        aria-label="Month View"
+      >
+        <div className="rbc-row rbc-month-header" role="row">
           {this.renderHeaders(weeks[0])}
         </div>
         {weeks.map(this.renderWeek)}
@@ -160,6 +164,7 @@ class MonthView extends React.Component {
           isOffRange && 'rbc-off-range',
           isCurrent && 'rbc-current'
         )}
+        role="cell"
       >
         <DateHeaderComponent
           label={label}


### PR DESCRIPTION
While we're happy in general of being able to use this component for our work, the lack of accessibility has been quite the problem lately. This is not a full solution by _any_ means, but it can enable a screen-reader user to actually navigate through the table of events. Notice that this PR basically just adds roles and a few minor things; it should not crash anything!

One thing that I was unable to fix was the fact that the user is still unable to read the events per se; in our custom code we had to resort to move the focus once the situation was found from the front-end, but that's definitely no good!

Note: This mainly address the **Month** view. From what I've tested, the Week view will be basically invisible for the time being to screen-reader users!