### PR TITLE
Update react & react-dom peer-dep to support 17.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
     "bracketSpacing": true
   },
   "peerDependencies": {
-    "react": "^16.6.1",
-    "react-dom": "^16.6.1"
+    "react": "^16.6.1 || ^17",
+    "react-dom": "^16.6.1 || ^17"
   },
   "devDependencies": {
     "@4c/rollout": "^1.4.0",


### PR DESCRIPTION
I'm using the library in a react 17.x project and works perfectly, however the `npm install` shows the breaking dependency warning:

`npm WARN react-big-calendar@0.28.6 requires a peer of react@^16.6.1 but none is installed. You must install peer dependencies yourself.`

Also, using the paketo-buildpacks exits with error building the image:

`npm ERR! peer dep missing: react@^16.6.1, required by react-big-calendar@0.28.6`

Thanks for the help!