### PR TITLE
Use https for github pages link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An events calendar component built for React and made for modern browsers (read: IE10+) and uses flexbox over the classic tables-ception approach.
 
-[**DEMO and Docs**](http://jquense.github.io/react-big-calendar/examples/index.html)
+[**DEMO and Docs**](https://jquense.github.io/react-big-calendar/examples/index.html)
 
 Inspired by [Full Calendar](http://fullcalendar.io/).
 


### PR DESCRIPTION
Avoids the "insecure" warning in some browsers. GitHub pages are HTTPS enabled and my (very quick) test suggests that the whole site works fine with https.