### PR TITLE
Dnd: Offset is not needed

### DIFF
--- a/src/addons/dragAndDrop/WeekWrapper.js
+++ b/src/addons/dragAndDrop/WeekWrapper.js
@@ -65,7 +65,7 @@ class WeekWrapper extends React.Component {
 
     const slot = getSlotAtX(
       bounds,
-      point.x - this.eventOffsetLeft,
+      point.x,
       rtl,
       slotMetrics.slots
     )
@@ -160,15 +160,6 @@ class WeekWrapper extends React.Component {
       const { isAllDay } = this.props
       const { action } = this.context.draggable.dragAndDropAction
       const bounds = getBoundsForNode(node)
-
-      // eventOffsetLeft is distance from the left of the event to the initial
-      // mouseDown position. We need this later to compute the new top of the
-      // event during move operations, since the final location is really a
-      // delta from this point. note: if we want to DRY this with
-      // EventContainerWrapper, probably better just to capture the mouseDown
-      // point here and do the placement computation in handleMove()...
-      this.eventOffsetLeft = point.x - bounds.left
-
       const isInBox = pointInBox(bounds, point)
       return (
         action === 'move' || (action === 'resize' && (!isAllDay || isInBox))


### PR DESCRIPTION
https://github.com/jquense/react-big-calendar/issues/1886

Drag and drop is currently using the very left edge of the calendar as an offset from the mousedown position. 
Resulting in unusable behavior. 

`getSlotAtX` is being sent an `x` value of `point.x - point.x - bounds.left`

It appears with the last few merged commits that `eventOffsetLeft` is no longer needed and removing it fixes all issues.  
