### PR TITLE
Improve the date-fns example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,23 +78,23 @@ const MyCalendar = props => (
 )
 ```
 
-#### date-fns 2.0
+#### date-fns v2
 
 ```js
 import { Calendar, dateFnsLocalizer } from 'react-big-calendar'
-import format from 'date-fns/format'
-import parse from 'date-fns/parse'
-import startOfWeek from 'date-fns/startOfWeek'
-import getDay from 'date-fns/getDay'
+import { format, parse, startOfWeek, getDay } from 'date-fns'
+import { enUS } from 'date-fns/locale'
+
 const locales = {
-  'en-US': require('date-fns/locale/en-US'),
+  'en-US': enUS
 }
+
 const localizer = dateFnsLocalizer({
   format,
   parse,
   startOfWeek,
   getDay,
-  locales,
+  locales
 })
 
 const MyCalendar = props => (

--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ const MyCalendar = props => (
 
 ```js
 import { Calendar, dateFnsLocalizer } from 'react-big-calendar'
-import format from 'date-fns/format';
-import parse from 'date-fns/parse';
-import startOfWeek from 'date-fns/startOfWeek';
-import getDay from 'date-fns/getDay';
-import enUS from 'date-fns/locale/en-US';
+import format from 'date-fns/format'
+import parse from 'date-fns/parse'
+import startOfWeek from 'date-fns/startOfWeek'
+import getDay from 'date-fns/getDay'
+import enUS from 'date-fns/locale/en-US'
 
 const locales = {
   'en-US': enUS
@@ -97,7 +97,7 @@ const localizer = dateFnsLocalizer({
   parse,
   startOfWeek,
   getDay,
-  locales
+  locales,
 })
 
 const MyCalendar = props => (

--- a/README.md
+++ b/README.md
@@ -82,8 +82,11 @@ const MyCalendar = props => (
 
 ```js
 import { Calendar, dateFnsLocalizer } from 'react-big-calendar'
-import { format, parse, startOfWeek, getDay } from 'date-fns'
-import { enUS } from 'date-fns/locale'
+import format from 'date-fns/format';
+import parse from 'date-fns/parse';
+import startOfWeek from 'date-fns/startOfWeek';
+import getDay from 'date-fns/getDay';
+import enUS from 'date-fns/locale/en-US';
 
 const locales = {
   'en-US': enUS


### PR DESCRIPTION
Per date-fns/date-fns#2474, the `date-fns` example in the readme might've been wrong/broken. I am not familiar with your project, so please double-check that this suggestion is OK!