### PR TITLE
Avoid popups closing immediatly with React 17

### DIFF
--- a/src/EventEndingRow.js
+++ b/src/EventEndingRow.js
@@ -93,6 +93,7 @@ class EventEndingRow extends React.Component {
 
   showMore(slot, e) {
     e.preventDefault()
+    e.stopPropagation()
     this.props.onShowMore(slot, e.target)
   }
 }


### PR DESCRIPTION
Since updating to React 17, the "show more" popup hasn't been working on a project I work on. This fix prevents the popup from closing immediately when being opened, by stopping the propagation of the click event on the "show more" text.