### PR TITLE
Update variables.scss to fix breaking change

### DIFF
--- a/src/sass/variables.scss
+++ b/src/sass/variables.scss
@@ -7,7 +7,7 @@ $cell-border: #DDD !default;
 
 $border-color: #CCC !default;
 
-$segment-width: percentage(1 / 7) !default;
+$segment-width: calc(100% / 7) !default;
 
 $time-selection-color: white !default;
 $time-selection-bg-color: rgba(0,0,0, .50) !default;


### PR DESCRIPTION
Breaking change caused by deprecation of node-sass. 

New version sass (dart-sass) requires division be used differently [math.div()]. So updated this to use vanilla css.

I guess it is important to note that you only get this error if you upgrade to dart-sass from node-sass. However, this fix provides backwards compatibility.