### PR TITLE
Resize overflow event cause `Invalid Date`

### DIFF
--- a/src/addons/dragAndDrop/EventContainerWrapper.js
+++ b/src/addons/dragAndDrop/EventContainerWrapper.js
@@ -81,9 +81,15 @@ class EventContainerWrapper extends React.Component {
 
     let { start, end } = eventTimes(event, accessors)
     if (direction === 'UP') {
-      start = dates.min(newTime, slotMetrics.closestSlotFromDate(end, -1))
+      start = dates.min(
+        newTime,
+        slotMetrics.closestSlotFromDate(end, -1) || newTime
+      )
     } else if (direction === 'DOWN') {
-      end = dates.max(newTime, slotMetrics.closestSlotFromDate(start))
+      end = dates.max(
+        newTime,
+        slotMetrics.closestSlotFromDate(start) || newTime
+      )
     }
 
     this.update(event, slotMetrics.getRange(start, end))

--- a/stories/DragAndDrop.js
+++ b/stories/DragAndDrop.js
@@ -1,8 +1,9 @@
+import moment from 'moment'
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
-import { events, Calendar, Views, DragAndDropCalendar } from './helpers'
+import { events, Views, DragAndDropCalendar } from './helpers'
 import customComponents from './helpers/customComponents'
 
 storiesOf('Drag and Drop', module)
@@ -45,6 +46,37 @@ storiesOf('Drag and Drop', module)
       />
     )
   })
+  .add(
+    'draggable and resizable with event overflows the custom time period',
+    () => {
+      return (
+        <DragAndDropCalendar
+          defaultDate={new Date()}
+          defaultView={Views.WEEK}
+          events={[
+            {
+              title: 'test larger',
+              start: moment()
+                .startOf('day')
+                .add(5, 'hours')
+                .toDate(),
+              end: moment()
+                .startOf('day')
+                .add(10, 'hours')
+                .toDate(),
+              allDay: false,
+            },
+          ]}
+          resizable
+          showMultiDayTimes
+          onEventDrop={action('event dropped')}
+          onEventResize={action('event resized')}
+          min={moment('04:00am', 'h:mma').toDate()}
+          max={moment('08:00am', 'h:mma').toDate()}
+        />
+      )
+    }
+  )
   .add('draggable and resizable with custom dateCellWrapper', () => {
     return (
       <DragAndDropCalendar


### PR DESCRIPTION
Resizing `startDate` of multi-day events or events that overlaps `max` of the calendar, make the `startDate` 'Invalid Date'

`dates.min` of `[Date, undfined]` returns `Invalid Date`.
Add fallback date from `closestSlotFromPoint` if no `closestSlotFromDate` found.

This should fix #1598, #1199, and partially the #2011

It could be reproduced on the 'draggable and resizable with showMultiDayTimes' page of the storybook, but for custom `min` and `max` calendar props I added 'draggable and resizable with event overflows the custom time period'