### PR TITLE
Fixes the isSelected function to work if the value is equal

### DIFF
--- a/src/utils/selection.js
+++ b/src/utils/selection.js
@@ -1,6 +1,8 @@
+import isEqual from 'lodash/isEqual'
+
 export function isSelected(event, selected) {
   if (!event || selected == null) return false
-  return [].concat(selected).indexOf(event) !== -1
+  return isEqual(event, selected)
 }
 
 export function slotWidth(rowBox, slots) {
@@ -18,7 +20,7 @@ export function getSlotAtX(rowBox, x, rtl, slots) {
 }
 
 export function pointInBox(box, { x, y }) {
-  return y >= box.top && y <= box.bottom && (x >= box.left && x <= box.right)
+  return y >= box.top && y <= box.bottom && x >= box.left && x <= box.right
 }
 
 export function dateCellSelection(start, rowBox, box, slots, rtl) {

--- a/test/utils/selection.test.js
+++ b/test/utils/selection.test.js
@@ -1,0 +1,38 @@
+import { isSelected } from '../../src/utils/selection'
+
+describe('isSelected', () => {
+  test('it returns true if it is the same object by reference', () => {
+    const value = {
+      x: { sample: 'value' },
+      y: 1,
+    }
+    expect(isSelected(value, value)).toBeTruthy()
+  })
+
+  test('it returns true if it is the same object by equality', () => {
+    const value = {
+      x: { sample: 'value' },
+      y: 1,
+    }
+
+    const equalivalentValue = {
+      x: { sample: 'value' },
+      y: 1,
+    }
+    expect(isSelected(value, equalivalentValue)).toBeTruthy()
+  })
+
+  test('it returns false if the object is not equal', () => {
+    const value = {
+      x: { sample: 'value' },
+      y: 1,
+    }
+
+    const nonEqualivalentValue = {
+      x: { sample: 'value' },
+      y: 2,
+    }
+
+    expect(isSelected(value, nonEqualivalentValue)).toBeFalsy()
+  })
+})


### PR DESCRIPTION
## Problem

I had noticed that, when using `react-big-calendar` I would pass the event that was selected, but the rendered component would not be selected (the `selected` prop was `false`).

Upon investigating, I found it to be an issue with the `isSelected` function. I wrote tests to confirm this.

Here is the output of the tests before the code change:

```
√:react-big-calendar rdbaker $ yarn test
yarn run v1.22.5
$ yarn lint && jest
$ eslint src test
Warning: React version not specified in eslint-plugin-react settings. See https://github.com/yannickcr/eslint-plugin-react#configuration .
 PASS  test/utils/TimeSlots.test.js
 PASS  test/utils/eventLevels.test.js (5.138s)
 PASS  test/utils/DayEventLayout.test.js (5.265s)
 FAIL  test/utils/selection.test.js
  ● isSelected › it returns true if it is the same object by equality

    expect(received).toBeTruthy()

    Received: false

      23 |       y: 1
      24 |     }
    > 25 |     expect(isSelected(value, equalivalentValue)).toBeTruthy()
         |                                                  ^
      26 |   })
      27 |
      28 |   test('it returns false if the object is not equal', () => {

      at Object.<anonymous> (test/utils/selection.test.js:25:50)

Test Suites: 1 failed, 3 passed, 4 total
Tests:       1 failed, 75 passed, 76 total
Snapshots:   0 total
Time:        7.397s
Ran all test suites.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

And here is the output after the code change:

```
?1:react-big-calendar rdbaker $ yarn test
yarn run v1.22.5
$ yarn lint && jest
$ eslint src test
Warning: React version not specified in eslint-plugin-react settings. See https://github.com/yannickcr/eslint-plugin-react#configuration .
 PASS  test/utils/DayEventLayout.test.js
 PASS  test/utils/eventLevels.test.js
 PASS  test/utils/TimeSlots.test.js
 PASS  test/utils/selection.test.js

Test Suites: 4 passed, 4 total
Tests:       76 passed, 76 total
Snapshots:   0 total
Time:        3.206s, estimated 6s
Ran all test suites.
✨  Done in 10.27s.
```

I didn't find a doc on how to structure contributions to this repo, so I laid it out as clearly as I could (granted, I didn't look at past merged contributions, I can take a look at that). Feel free to mark this up with comments/edits.