### PR TITLE
Add resizing and dragging events

### DIFF
--- a/src/addons/dragAndDrop/EventContainerWrapper.js
+++ b/src/addons/dragAndDrop/EventContainerWrapper.js
@@ -70,7 +70,18 @@ class EventContainerWrapper extends React.Component {
 
     const { duration } = eventTimes(event, accessors, this.props.localizer)
     let newEnd = this.props.localizer.add(newSlot, duration, 'milliseconds')
-    this.update(event, slotMetrics.getRange(newSlot, newEnd, false, true))
+    const positionData = slotMetrics.getRange(newSlot, newEnd, false, true)
+
+    // Skip updates, when return "false" in onDragging event
+    if (
+      this.context.draggable.onDragging &&
+      this.context.draggable.onDragging({
+        event, start: positionData.startDate, end: positionData.endDate,
+      }) === false
+    ) {
+      return
+    }
+    this.update(event, positionData)
   }
 
   handleResize(point, bounds) {
@@ -85,7 +96,18 @@ class EventContainerWrapper extends React.Component {
       end = localizer.max(newTime, slotMetrics.closestSlotFromDate(start))
     }
 
-    this.update(event, slotMetrics.getRange(start, end))
+    const positionData = slotMetrics.getRange(start, end)
+
+    // Skip updates, when return "false" in onResizing event
+    if (
+      this.context.draggable.onResizing &&
+      this.context.draggable.onResizing({
+        event, start: positionData.startDate, end: positionData.endDate,
+      }) === false
+    ) {
+      return
+    }
+    this.update(event, positionData)
   }
 
   handleDropFromOutside = (point, boundaryBox) => {

--- a/src/addons/dragAndDrop/README.md
+++ b/src/addons/dragAndDrop/README.md
@@ -23,12 +23,14 @@ return (
 Set `resizable` to false in your calendar if you don't want events to be resizable.
 `resizable` is set to true by default.
 
-The HOC adds `onEventDrop`, `onEventResize`, and `onDragStart` callback properties if the events are
+The HOC adds `onEventDrop`, `onEventResize`, `onEventResizing`, `onEventDragging` and `onDragStart` callback properties if the events are
 moved or resized. These callbacks are called with these signatures:
 
 ```js
    function onEventDrop({ event, start, end, allDay }) {...}
-   function onEventResize(type, { event, start, end, allDay }) {...}  // type is always 'drop'
+   function onEventDragging({ event, start, end }) {...} // when return "false" prevent dragging
+   function onEventResize({ event, start, end, allDay }) {...}
+   function onEventResizing({ event, start, end }) {...} // when return "false" prevent resizing
    function onDragStart({ event, action, direction }) {...}
 ```
 

--- a/src/addons/dragAndDrop/withDragAndDrop.js
+++ b/src/addons/dragAndDrop/withDragAndDrop.js
@@ -19,6 +19,8 @@ export default function withDragAndDrop(Calendar) {
       onDragStart: PropTypes.func,
       onDragOver: PropTypes.func,
       onDropFromOutside: PropTypes.func,
+      onEventResizing: PropTypes.func,
+      onEventDragging: PropTypes.func,
 
       dragFromOutsideItem: PropTypes.func,
 
@@ -57,6 +59,8 @@ export default function withDragAndDrop(Calendar) {
           onEnd: this.handleInteractionEnd,
           onBeginAction: this.handleBeginAction,
           onDropFromOutside: this.props.onDropFromOutside,
+          onResizing: this.props.onEventResizing,
+          onDragging: this.props.onEventDragging,
           dragFromOutsideItem: this.props.dragFromOutsideItem,
           draggableAccessor: this.props.draggableAccessor,
           resizableAccessor: this.props.resizableAccessor,


### PR DESCRIPTION
Introduce `onEventResizing` and `onEventDragging` events to handle resize and drag events.