### PR TITLE
fix: pass dates to slotGroupPropGetter

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -569,7 +569,7 @@ class Calendar extends React.Component {
      * Optionally provide a function that returns an object of props to be applied
      * to the time-slot group node. Useful to dynamically change the sizing of time nodes.
      * ```js
-     * () => { style?: Object }
+     * (group: Date[]) => { style?: Object }
      * ```
      */
     slotGroupPropGetter: PropTypes.func,

--- a/src/TimeSlotGroup.js
+++ b/src/TimeSlotGroup.js
@@ -14,7 +14,7 @@ export default class TimeSlotGroup extends Component {
       components: { timeSlotWrapper: Wrapper = BackgroundWrapper } = {},
     } = this.props
 
-    const groupProps = getters ? getters.slotGroupProp() : {}
+    const groupProps = getters ? getters.slotGroupProp(group) : {}
     return (
       <div className="rbc-timeslot-group" {...groupProps}>
         {group.map((value, idx) => {

--- a/stories/props/API.stories.mdx
+++ b/stories/props/API.stories.mdx
@@ -621,7 +621,7 @@ Optionally provide a function that returns an object of className or style props
 
 ### slotGroupPropGetter
 
-- type: `function () => { style?: Object }`
+- type: `function (group: Date[]) => { style?: Object }`
 - <LinkTo kind="props" story="slot-group-prop-getter">
     Example
   </LinkTo>

--- a/stories/props/slotGroupPropGetter.mdx
+++ b/stories/props/slotGroupPropGetter.mdx
@@ -3,7 +3,7 @@ import LinkTo from '@storybook/addon-links/react'
 
 # slotGroupPropGetter
 
-- type: `function () => { style?: Object }`
+- type: `function (group: Date[]) => { style?: Object }`
 
 Optionally provide a function that returns an object of className or style props to be applied to the time-slot node.
 


### PR DESCRIPTION
Personally I use it to handle DST differently but also could be used to style group based on date.
Also based on the source code https://github.com/jquense/react-big-calendar/blob/ad8defa643692911fd0b00c71b70de94715140a9/src/Calendar.js#L916 something like that was supposed to be done