### PR TITLE
Resize One Day more than hover Date Cell

### DIFF
--- a/src/addons/dragAndDrop/WeekWrapper.js
+++ b/src/addons/dragAndDrop/WeekWrapper.js
@@ -108,7 +108,9 @@ class WeekWrapper extends React.Component {
     if (direction === 'RIGHT') {
       if (cursorInRow) {
         if (slotMetrics.last < start) return this.reset()
-        end = localizer.add(date, 1, 'day')
+        if (localizer.eq(localizer.startOf(end, 'day'), end))
+          end = localizer.add(date, 1, 'day')
+        else end = date
       } else if (
         localizer.inRange(start, slotMetrics.first, slotMetrics.last) ||
         (bounds.bottom < point.y && +slotMetrics.first > +start)
@@ -151,6 +153,8 @@ class WeekWrapper extends React.Component {
     let container = node.closest('.rbc-month-view, .rbc-time-view')
 
     let selector = (this._selector = new Selection(() => container))
+
+    console.log(node, container)
 
     selector.on('beforeSelect', point => {
       const { isAllDay } = this.props


### PR DESCRIPTION
Recently, Our project use RBC as OS library to our schedule management, However we find the resize func will plus one day to hover date.

For example:
If we hover the 12/2 as the end date we want, the event end date we previewed is 12/3.

We don't know if author do it Intentionally. 
 If not let us merge our request please