### PR TITLE
fix: Update deprecated-to-be syntax on less variable

### DIFF
--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -7,7 +7,7 @@
 
 @border-color: #CCC;
 
-@segment-width: percentage(1 / 7);
+@segment-width: percentage(math.div(1, 7));
 
 @time-selection-color: white;
 @time-selection-bg-color: rgba(0,0,0, .50);


### PR DESCRIPTION
Following [Sass' docs](https://sass-lang.com/documentation/breaking-changes/slash-div), using slash as a division will no longer be supported, this addresses said breaking change.