### PR TITLE
fix(sass): Reference distributed folder in SASS compile

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "./dist/react-big-calendar.js": {
-    "bundled": 536877,
-    "minified": 165660,
-    "gzipped": 51022
+    "bundled": 536878,
+    "minified": 165661,
+    "gzipped": 51020
   },
   "./dist/react-big-calendar.min.js": {
-    "bundled": 464776,
-    "minified": 143848,
-    "gzipped": 45240
+    "bundled": 464777,
+    "minified": 143849,
+    "gzipped": 45238
   },
   "dist/react-big-calendar.esm.js": {
-    "bundled": 220156,
-    "minified": 99914,
-    "gzipped": 24835,
+    "bundled": 220157,
+    "minified": 99915,
+    "gzipped": 24833,
     "treeshaked": {
       "rollup": {
-        "code": 63400,
+        "code": 63401,
         "import_statements": 1445
       },
       "webpack": {
-        "code": 66893
+        "code": 66894
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-big-calendar",
-  "version": "0.38.2",
+  "version": "0.38.3",
   "description": "Calendar! with events",
   "author": {
     "name": "Jason Quense",

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   "scripts": {
     "clean": "rimraf lib",
     "clean:examples": "rimraf examples/static",
-    "s": "sass src/sass/styles.scss ./lib/css/react-big-calendar.css",
+    "s": "sass ./lib/sass/styles.scss ./lib/css/react-big-calendar.css",
     "sass": "yarn s  && yarn sass-dnd",
-    "sass-dnd": "sass src/addons/dragAndDrop/styles.scss ./lib/addons/dragAndDrop/styles.css",
+    "sass-dnd": "sass ./lib/addons/dragAndDrop/styles.scss ./lib/addons/dragAndDrop/styles.css",
     "autoprefixer": "postcss ./lib/css/react-big-calendar.css && postcss ./lib/addons/dragAndDrop/styles.css",
     "build:css": "yarn sass && yarn autoprefixer",
     "assets": "cpy src/sass/* lib/sass && yarn assets-addons",


### PR DESCRIPTION
Since `./src` folder is not distributed with package install, we must reference the `./lib` folder for proper sourcemapping in the CSS file.

This resolves issue #2086 