### PR TITLE
Fix monthly display showing nothing with no events

### DIFF
--- a/src/sass/month.scss
+++ b/src/sass/month.scss
@@ -53,6 +53,7 @@
   flex: 1 0 0; // postcss will remove the 0px here hence the duplication below
   flex-basis: 0px;
   overflow: hidden;
+  min-height: 75px;
 
   height: 100%; // ie-fix
 


### PR DESCRIPTION
Displaying the monthly calendar with no events opens up calendar entries with 0px height which shows nothing. Adding a minimum height to the row gives it a more (unbroken) look