### PR TITLE
FIX_RESIZE_BUG

### DIFF
--- a/src/addons/dragAndDrop/WeekWrapper.js
+++ b/src/addons/dragAndDrop/WeekWrapper.js
@@ -108,7 +108,9 @@ class WeekWrapper extends React.Component {
     if (direction === 'RIGHT') {
       if (cursorInRow) {
         if (slotMetrics.last < start) return this.reset()
-        end = localizer.add(date, 1, 'day')
+        if (localizer.eq(localizer.startOf(end, 'day'), end))
+          end = localizer.add(date, 1, 'day')
+        else end = date
       } else if (
         localizer.inRange(start, slotMetrics.first, slotMetrics.last) ||
         (bounds.bottom < point.y && +slotMetrics.first > +start)


### PR DESCRIPTION
### Fix resize bug when event end time not equals 0 am

**Issue**:
When event end  time equals  0 am, end day (because end day equals previous day)  plus 1 day is a correct move.
however, when event time end time after 0 am, end day do not need plus 1 day any more.

**For Author or Administer**:
Please check my PR, THX
