### PR TITLE
fix: Correct no overlap algorithm stretch behavior

### DIFF
--- a/src/utils/layout-algorithms/no-overlap.js
+++ b/src/utils/layout-algorithms/no-overlap.js
@@ -90,7 +90,7 @@ export default function({
     // stretch to maximum
     let maxIdx = 0
     for (let j = 0; j < e.friends.length; ++j) {
-      const idx = e.friends[j]
+      const idx = e.friends[j].idx
       maxIdx = maxIdx > idx ? maxIdx : idx
     }
     if (maxIdx <= e.idx) e.size = 100 - e.idx * e.size


### PR DESCRIPTION
Slight bug that prevents the stretch behavior of the no overlap algorithm from working properly

Without the fix:
![without](https://user-images.githubusercontent.com/5350362/152580151-c4aabba7-a3a7-4199-aecf-0eced1954f22.png)

With the fix:
![with](https://user-images.githubusercontent.com/5350362/152580182-7014c9e5-cb1a-4995-9789-5883e4cfdd78.png)
