### PR TITLE
fix: Correct variable name that gets passed on to EventWrapper so dragndrop ha…

### DIFF
--- a/examples/demos/dnd.js
+++ b/examples/demos/dnd.js
@@ -106,6 +106,7 @@ class Dnd extends React.Component {
         onEventDrop={this.moveEvent}
         resizable
         onEventResize={this.resizeEvent}
+        showMultiDayTimes={true}
         onSelectSlot={this.newEvent}
         onDragStart={console.log}
         defaultView={Views.MONTH}

--- a/examples/events.js
+++ b/examples/events.js
@@ -83,9 +83,9 @@ export default [
   },
   {
     id: 11.1,
-    title: 'Inconvenient Conference Call',
+    title: 'Inconvenient multi-day Conference Call',
     start: new Date(2015, 3, 13, 9, 30, 0),
-    end: new Date(2015, 3, 13, 12, 0, 0),
+    end: new Date(2015, 3, 14, 1, 0, 0),
   },
   {
     id: 11.2,

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -221,8 +221,8 @@ class DayColumn extends React.Component {
       if (startsBeforeDay && startsAfterDay) label = messages.allDay
       else label = localizer.format({ start, end }, format)
 
-      let continuesEarlier = startsBeforeDay || slotMetrics.startsBefore(start)
-      let continuesLater = startsAfterDay || slotMetrics.startsAfter(end)
+      let continuesPrior = startsBeforeDay || slotMetrics.startsBefore(start)
+      let continuesAfter = startsAfterDay || slotMetrics.startsAfter(end)
 
       return (
         <TimeGridEvent
@@ -233,8 +233,8 @@ class DayColumn extends React.Component {
           getters={getters}
           rtl={rtl}
           components={components}
-          continuesEarlier={continuesEarlier}
-          continuesLater={continuesLater}
+          continuesPrior={continuesPrior}
+          continuesAfter={continuesAfter}
           accessors={accessors}
           selected={isSelected(event, selected)}
           onClick={e => this._select(event, e)}

--- a/src/TimeGridEvent.js
+++ b/src/TimeGridEvent.js
@@ -15,8 +15,8 @@ function TimeGridEvent(props) {
     rtl,
     selected,
     label,
-    continuesEarlier,
-    continuesLater,
+    continuesPrior,
+    continuesAfter,
     getters,
     onClick,
     onDoubleClick,
@@ -76,8 +76,8 @@ function TimeGridEvent(props) {
           userProps.className,
           {
             'rbc-selected': selected,
-            'rbc-event-continues-earlier': continuesEarlier,
-            'rbc-event-continues-later': continuesLater,
+            'rbc-event-continues-earlier': continuesPrior,
+            'rbc-event-continues-later': continuesAfter,
           }
         )}
       >

--- a/src/addons/dragAndDrop/EventContainerWrapper.js
+++ b/src/addons/dragAndDrop/EventContainerWrapper.js
@@ -237,8 +237,8 @@ class EventContainerWrapper extends React.Component {
               getters={getters}
               components={{ ...components, eventWrapper: NoopWrapper }}
               accessors={{ ...accessors, ...dragAccessors }}
-              continuesEarlier={startsBeforeDay}
-              continuesLater={startsAfterDay}
+              continuesPrior={startsBeforeDay}
+              continuesAfter={startsAfterDay}
             />
           )}
         </React.Fragment>


### PR DESCRIPTION
Fix variable name that gets passed on to EventWrapper so dragndrop has access tocontinuesPrior and continuesAfter flags.
Based on these flags, drag n drop determine whether to show north-south anchors
for multi day events.


Before Fix:
* Multi day event shows an anchor on the top even if it was continued from before.
* Multi day event shows an anchor on the bottom even if it is continued after.


After Fix:
* Multi day event doesn't show north anchor and only south anchor if it was continued from before.
* Multi day event doesn't show south anchor and only north anchor if it is continued after.