### PR TITLE
chore: Expose slotMetrics to DayColumnWrapper component

### DIFF
--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -139,6 +139,7 @@ class DayColumn extends React.Component {
           isNow && 'rbc-today', // WHY
           selecting && 'rbc-slot-selecting'
         )}
+        slotMetrics={slotMetrics}
       >
         {slotMetrics.groups.map((grp, idx) => (
           <TimeSlotGroup


### PR DESCRIPTION
* DayColumnWrapper is incredibly helpful component.
* slotMetrics is already exposed in EventContainerWrapper component and with this fix will be exposed to DayColumnWrapper component as well.