### PR TITLE
Add a functionality to disable auto-scroll on calendar render.

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -610,6 +610,11 @@ class Calendar extends React.Component {
     scrollToTime: PropTypes.instanceOf(Date),
 
     /**
+     * Determines whether the scroll pane is automatically scrolled down or not.
+     */
+    enableAutoScroll: PropTypes.bool,
+
+    /**
      * Specify a specific culture code for the Calendar.
      *
      * **Note: it's generally better to handle this globally via your i18n library.**

--- a/src/Day.js
+++ b/src/Day.js
@@ -17,6 +17,7 @@ class Day extends React.Component {
       min = localizer.startOf(new Date(), 'day'),
       max = localizer.endOf(new Date(), 'day'),
       scrollToTime = localizer.startOf(new Date(), 'day'),
+      enableAutoScroll = true,
       ...props
     } = this.props
     let range = Day.range(date, { localizer: localizer })
@@ -30,6 +31,7 @@ class Day extends React.Component {
         min={min}
         max={max}
         scrollToTime={scrollToTime}
+        enableAutoScroll={enableAutoScroll}
       />
     )
   }
@@ -41,6 +43,7 @@ Day.propTypes = {
   min: PropTypes.instanceOf(Date),
   max: PropTypes.instanceOf(Date),
   scrollToTime: PropTypes.instanceOf(Date),
+  enableAutoScroll: PropTypes.bool,
 }
 
 Day.range = (date, { localizer }) => {

--- a/src/Month.js
+++ b/src/Month.js
@@ -346,6 +346,7 @@ MonthView.propTypes = {
   getNow: PropTypes.func.isRequired,
 
   scrollToTime: PropTypes.instanceOf(Date),
+  enableAutoScroll: PropTypes.bool,
   rtl: PropTypes.bool,
   resizable: PropTypes.bool,
   width: PropTypes.number,

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -303,7 +303,8 @@ export default class TimeGrid extends Component {
   }
 
   applyScroll() {
-    if (this._scrollRatio != null) {
+    // If auto-scroll is disabled, we don't actually apply the scroll
+    if (this._scrollRatio != null && this.props.enableAutoScroll === true) {
       const content = this.contentRef.current
       content.scrollTop = content.scrollHeight * this._scrollRatio
       // Only do this once
@@ -352,6 +353,7 @@ TimeGrid.propTypes = {
   getNow: PropTypes.func.isRequired,
 
   scrollToTime: PropTypes.instanceOf(Date).isRequired,
+  enableAutoScroll: PropTypes.bool,
   showMultiDayTimes: PropTypes.bool,
 
   rtl: PropTypes.bool,

--- a/src/Week.js
+++ b/src/Week.js
@@ -16,6 +16,7 @@ class Week extends React.Component {
       min = localizer.startOf(new Date(), 'day'),
       max = localizer.endOf(new Date(), 'day'),
       scrollToTime = localizer.startOf(new Date(), 'day'),
+      enableAutoScroll = true,
       ...props
     } = this.props
     let range = Week.range(date, this.props)
@@ -29,6 +30,7 @@ class Week extends React.Component {
         min={min}
         max={max}
         scrollToTime={scrollToTime}
+        enableAutoScroll={enableAutoScroll}
       />
     )
   }
@@ -40,6 +42,7 @@ Week.propTypes = {
   min: PropTypes.instanceOf(Date),
   max: PropTypes.instanceOf(Date),
   scrollToTime: PropTypes.instanceOf(Date),
+  enableAutoScroll: PropTypes.bool,
 }
 
 Week.defaultProps = TimeGrid.defaultProps

--- a/src/WorkWeek.js
+++ b/src/WorkWeek.js
@@ -23,6 +23,7 @@ class WorkWeek extends React.Component {
       min = localizer.startOf(new Date(), 'day'),
       max = localizer.endOf(new Date(), 'day'),
       scrollToTime = localizer.startOf(new Date(), 'day'),
+      enableAutoScroll = true,
       ...props
     } = this.props
     let range = workWeekRange(date, this.props)
@@ -35,6 +36,7 @@ class WorkWeek extends React.Component {
         min={min}
         max={max}
         scrollToTime={scrollToTime}
+        enableAutoScroll={enableAutoScroll}
       />
     )
   }
@@ -46,6 +48,7 @@ WorkWeek.propTypes = {
   min: PropTypes.instanceOf(Date),
   max: PropTypes.instanceOf(Date),
   scrollToTime: PropTypes.instanceOf(Date),
+  enableAutoScroll: PropTypes.bool,
 }
 
 WorkWeek.defaultProps = TimeGrid.defaultProps


### PR DESCRIPTION
#### Do you want to request a _feature_ or report a _bug_?
Feature

#### Feature
* Users should be able to disable auto-scroll which happens when calendar is rendered.
 
#### What's the expected behavior?
* By default we enable the auto-scroll, users have a mechanism to disable autoscroll.

#### Related Discussion
* https://github.com/jquense/react-big-calendar/issues/1717

