### PR TITLE
fix: Correct resize for multi-day event.

### DIFF
--- a/src/addons/dragAndDrop/EventContainerWrapper.js
+++ b/src/addons/dragAndDrop/EventContainerWrapper.js
@@ -79,13 +79,34 @@ class EventContainerWrapper extends React.Component {
     const newTime = slotMetrics.closestSlotFromPoint(point, bounds)
 
     let { start, end } = eventTimes(event, accessors, localizer)
+    let newRange
     if (direction === 'UP') {
-      start = localizer.min(newTime, slotMetrics.closestSlotFromDate(end, -1))
+      const newStart = localizer.min(
+        newTime,
+        slotMetrics.closestSlotFromDate(end, -1)
+      )
+      // Get the new range based on the new start
+      // but don't overwrite the end date as it could be outside this day boundary.
+      newRange = slotMetrics.getRange(newStart, end)
+      newRange = {
+        ...newRange,
+        endDate: end,
+      }
     } else if (direction === 'DOWN') {
-      end = localizer.max(newTime, slotMetrics.closestSlotFromDate(start))
+      // Get the new range based on the new end
+      // but don't overwrite the start date as it could be outside this day boundary.
+      const newEnd = localizer.max(
+        newTime,
+        slotMetrics.closestSlotFromDate(start)
+      )
+      newRange = slotMetrics.getRange(start, newEnd)
+      newRange = {
+        ...newRange,
+        startDate: start,
+      }
     }
 
-    this.update(event, slotMetrics.getRange(start, end))
+    this.update(event, newRange)
   }
 
   handleDropFromOutside = (point, boundaryBox) => {

--- a/src/utils/TimeSlots.js
+++ b/src/utils/TimeSlots.js
@@ -89,6 +89,7 @@ export function getSlotMetrics({
 
     closestSlotFromDate(date, offset = 0) {
       if (localizer.lt(date, start, 'minutes')) return slots[0]
+      if (localizer.gt(date, end, 'minutes')) return slots[slots.length - 1]
 
       const diffMins = localizer.diff(start, date, 'minutes')
       return slots[(diffMins - (diffMins % step)) / step + offset]


### PR DESCRIPTION
#### Do you want to request a _feature_ or report a _bug_?
Bug

#### What's the current behavior
* When users try to resize a multi-day event, the resize just changes the event start/end as per that day's start/end.
 
#### What's the expected behavior?
* Resizing a multi day event should change just the start or end of the event and the start/end across the other days should remain consistent.

