### PR TITLE
fix: disable `absoluteRuntime` in babel-preset-react-app

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -24,26 +24,26 @@
     }
   },
   "react-big-calendar.js": {
-    "bundled": 1583203,
-    "minified": 445033,
-    "gzipped": 137433
+    "bundled": 1583365,
+    "minified": 445101,
+    "gzipped": 137464
   },
   "react-big-calendar.min.js": {
-    "bundled": 283207,
-    "minified": 281758,
-    "gzipped": 88844
+    "bundled": 283536,
+    "minified": 281826,
+    "gzipped": 88860
   },
   "react-big-calendar.esm.js": {
-    "bundled": 206455,
-    "minified": 97326,
-    "gzipped": 25439,
+    "bundled": 200119,
+    "minified": 93592,
+    "gzipped": 24251,
     "treeshaked": {
       "rollup": {
-        "code": 69823,
-        "import_statements": 1103
+        "code": 66279,
+        "import_statements": 1777
       },
       "webpack": {
-        "code": 72947
+        "code": 70059
       }
     }
   }

--- a/babel.config.js
+++ b/babel.config.js
@@ -13,7 +13,7 @@ module.exports = function (api) {
           }),
         },
       ],
-      'react-app',
+      ['react-app', { absoluteRuntime: false }],
     ],
     plugins: [
       ['@babel/plugin-transform-runtime'],


### PR DESCRIPTION
Fixes #2153 

Changes in e5721ef127d407a12ac74514981b311a1558fd2b seems to have enabled absolute runtime imports during builds for v0.39.4 which results in absolute paths to `@babel/runtime`. This can be verified by checking one of the built files: https://unpkg.com/react-big-calendar@0.39.4/lib/Calendar.js (see [v0.39.3](https://unpkg.com/react-big-calendar@0.39.3/lib/Calendar.js) for comparison)

This fixes the issue by setting `"absoluteRuntime": false` config option for `babel-preset-react-app`.