### PR TITLE
fix: move react, react-dom to devDependencies

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -24,26 +24,26 @@
     }
   },
   "react-big-calendar.js": {
-    "bundled": 1583440,
-    "minified": 445148,
-    "gzipped": 137477
+    "bundled": 1583435,
+    "minified": 445376,
+    "gzipped": 137501
   },
   "react-big-calendar.min.js": {
-    "bundled": 283203,
-    "minified": 281754,
-    "gzipped": 88847
+    "bundled": 283187,
+    "minified": 281738,
+    "gzipped": 88836
   },
   "react-big-calendar.esm.js": {
-    "bundled": 199942,
-    "minified": 93434,
-    "gzipped": 24203,
+    "bundled": 199459,
+    "minified": 93011,
+    "gzipped": 24119,
     "treeshaked": {
       "rollup": {
-        "code": 66290,
+        "code": 66234,
         "import_statements": 1804
       },
       "webpack": {
-        "code": 70070
+        "code": 70014
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,11 @@
     "test": "yarn lint && NODE_ENV=test jest",
     "tdd": "NODE_ENV=test jest --watch"
   },
+  "peerDependencies": {
+    "moment": "^2.29.1",
+    "react": "^16.14.0 || ^17",
+    "react-dom": "^16.14.0 || ^17"
+  },
   "devDependencies": {
     "@babel/cli": "^7.17.6",
     "@babel/core": "^7.17.5",
@@ -92,8 +97,10 @@
     "postcss": "^8.4.8",
     "postcss-cli": "^9.1.0",
     "prettier": "^2.5.1",
+    "react": "^17.0.2",
     "react-bootstrap": "^0.32.4",
     "react-docgen": "^5.4.0",
+    "react-dom": "^17.0.2",
     "react-tackle-box": "^2.1.0",
     "regenerator-runtime": "^0.13.9",
     "rollup": "^2.70.0",
@@ -118,8 +125,6 @@
     "lodash-es": "^4.17.21",
     "memoize-one": "^6.0.0",
     "prop-types": "^15.8.1",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
     "react-overlays": "^4.1.1",
     "uncontrollable": "^7.2.1"
   },


### PR DESCRIPTION
Possible fix for #2151 

This commit moves `react` and `react-dom` back into `devDependencies`.

`react` and `react-dom` needs to be in `devDependencies` to avoid issues arising from loading multiple react versions when RBC is installed. I was able to verify this happening by installing rbc 0.39.6 to a CRA project with `react@16.14.0`. In that case, both the project's version and the library's `17.x` version were installed causing issues running the project.

Additionally, supported react/react-dom/moment versions are also listed in `peerDependencies`.