### PR TITLE
feat(events): default events prop to an empty array

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx lint-staged
+NODE_ENV=development npx lint-staged

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -845,6 +845,8 @@ class Calendar extends React.Component {
   }
 
   static defaultProps = {
+    events: [],
+    backgroundEvents: [],
     elementProps: {},
     popup: false,
     toolbar: true,
@@ -981,7 +983,7 @@ class Calendar extends React.Component {
       view,
       toolbar,
       events,
-      backgroundEvents = [],
+      backgroundEvents,
       style,
       className,
       elementProps,

--- a/stories/props/API.stories.mdx
+++ b/stories/props/API.stories.mdx
@@ -150,7 +150,8 @@ Callback fired when the `view` value changes. When included it is used to 'contr
 
 ### events
 
-- type: `arrayOf(Event)` **required**
+- type: `arrayOf(Event)`
+- default: `[]`
 - <LinkTo kind="props" story="events">
     Example
   </LinkTo>

--- a/stories/props/events.mdx
+++ b/stories/props/events.mdx
@@ -2,7 +2,8 @@ import { Canvas, Story } from '@storybook/addon-docs'
 
 # events
 
-- type: `arrayOf(Event)` **required**
+- type: `arrayOf(Event)`
+- default: `[]`
 
 An array of event objects to display on the calendar. Events objects
 can be any shape, as long as the Calendar knows how to retrieve the

--- a/stories/props/events.stories.js
+++ b/stories/props/events.stories.js
@@ -31,7 +31,7 @@ const Template = (args) => (
 )
 
 export const Events = Template.bind({})
-Events.storyName = 'events *'
+Events.storyName = 'events'
 Events.args = {
   defaultDate: new Date(2015, 3, 13),
   events: demoEvents,


### PR DESCRIPTION
Changes to default props to no longer make
events required, defaulting to an empty array

#1708
