### PR TITLE
fix: correct luxon localizer formatting

### DIFF
--- a/src/localizers/luxon.js
+++ b/src/localizers/luxon.js
@@ -63,7 +63,7 @@ export default function (DateTime, { firstDayOfWeek = 7 } = {}) {
   }
 
   function formatDateWithCulture(value, culture, format) {
-    return DateTime.fromJSDate(value).setLocale(culture).format(format)
+    return DateTime.fromJSDate(value).setLocale(culture).toFormat(format)
   }
 
   /*** BEGIN localized date arithmetic methods with Luxon ***/


### PR DESCRIPTION
Currently there is an error while using luxon localizer with custom culture.

The issue is because of invocation of wrong luxon method.
