### PR TITLE
2147 Fixed resetting event when resize action was done outside of container

### DIFF
--- a/src/Selection.js
+++ b/src/Selection.js
@@ -323,16 +323,14 @@ class Selection {
       return this.emit('reset')
     }
 
-    if (!inRoot) {
-      return this.emit('reset')
-    }
-
     if (click && inRoot) {
       return this._handleClickEvent(e)
     }
 
     // User drag-clicked in the Selectable area
     if (!click) return this.emit('select', bounds)
+
+    return this.emit('reset')
   }
 
   _handleClickEvent(e) {


### PR DESCRIPTION
Fixes the issue #2147  when resizing an event past the root container, also solves drag creating an event that had the same issue.

You can observe the issues here:
[Resizable story](https://jquense.github.io/react-big-calendar/examples/index.html?path=/story/addons-drag-and-drop-props--resizable) - resizing event past the container causes the event to reset.
[Create events story](https://jquense.github.io/react-big-calendar/examples/index.html?path=/story/examples--example-2) - creating an event while dragging causes the event to reset
