### PR TITLE
fix: resolve resizing in Month view

### DIFF
--- a/src/addons/dragAndDrop/WeekWrapper.js
+++ b/src/addons/dragAndDrop/WeekWrapper.js
@@ -151,12 +151,14 @@ class WeekWrapper extends React.Component {
   _selectable = () => {
     let node = this.ref.current.closest('.rbc-month-row, .rbc-allday-cell')
     let container = node.closest('.rbc-month-view, .rbc-time-view')
+    let isMonthRow = node.classList.contains('rbc-month-row')
 
-    let selector = (
-      this._selector = new Selection(
-        () => container,
-        { validContainers: ['.rbc-day-slot', '.rbc-allday-cell'] }
-      ))
+    // Valid container check only necessary in TimeGrid views
+    let selector = (this._selector = new Selection(() => container, {
+      validContainers: [
+        ...(!isMonthRow ? ['.rbc-day-slot', '.rbc-allday-cell'] : []),
+      ],
+    }))
 
     selector.on('beforeSelect', (point) => {
       const { isAllDay } = this.props


### PR DESCRIPTION
Resolves issue where user could no longer resize events in the Month view. Issue created in 0.40.3 in PR #2199.

#2207
