### PR TITLE
fix(dnd): dont use classname

### DIFF
--- a/src/addons/dragAndDrop/EventWrapper.js
+++ b/src/addons/dragAndDrop/EventWrapper.js
@@ -42,7 +42,9 @@ class EventWrapper extends React.Component {
     // hack: because of the way the anchors are arranged in the DOM, resize
     // anchor events will bubble up to the move anchor listener. Don't start
     // move operations when we're on a resize anchor.
-    const isResizeHandle = e.target.className.includes('rbc-addons-dnd-resize')
+    const isResizeHandle = e.target
+      .getAttribute('class')
+      ?.includes('rbc-addons-dnd-resize')
     if (!isResizeHandle)
       this.context.draggable.onBeginAction(this.props.event, 'move')
   }


### PR DESCRIPTION
## Description
Use getAttribute('class') instead of className. className can be an object
 as per web standards.

## Bug Fix
* This fixes a bug when there is className is a SVGAnimatedString inside the event card.
Web standards for className : https://developer.mozilla.org/en-US/docs/Web/API/Element/className#notes

## Testing
* I have not added a story for this bug, as such it is outside the scope of this project. We are just adhering to the right standards.
* The existing story for DnD is functional with this bug including resize not triggering movement. 
