### PR TITLE
fix: remove deprecated React.createFactory. #1831

### DIFF
--- a/src/addons/dragAndDrop/common.js
+++ b/src/addons/dragAndDrop/common.js
@@ -1,9 +1,13 @@
+import { createElement } from 'react'
 import { wrapAccessor } from '../../utils/accessors'
-import { createFactory } from 'react'
 
 export const dragAccessors = {
   start: wrapAccessor((e) => e.start),
   end: wrapAccessor((e) => e.end),
+}
+
+function createFactory(Component) {
+  return (props, ...children) => createElement(Component, props, ...children)
 }
 
 function nest(...Components) {


### PR DESCRIPTION

checked with story "draggable and resizable with custom eventWrapper"