### PR TITLE
Feature/add custom formats

### DIFF
--- a/src/localizers/moment.js
+++ b/src/localizers/moment.js
@@ -18,26 +18,18 @@ const timeRangeStartFormat = ({ start }, culture, local) =>
 const timeRangeEndFormat = ({ end }, culture, local) =>
   ' – ' + local.format(end, 'LT', culture)
 
-export const formats = {
+const defStringFormats = {
   dateFormat: 'DD',
   dayFormat: 'DD ddd',
   weekdayFormat: 'ddd',
-
-  selectRangeFormat: timeRangeFormat,
-  eventTimeRangeFormat: timeRangeFormat,
-  eventTimeRangeStartFormat: timeRangeStartFormat,
-  eventTimeRangeEndFormat: timeRangeEndFormat,
 
   timeGutterFormat: 'LT',
 
   monthHeaderFormat: 'MMMM YYYY',
   dayHeaderFormat: 'dddd MMM DD',
-  dayRangeHeaderFormat: weekRangeFormat,
-  agendaHeaderFormat: dateRangeFormat,
 
   agendaDateFormat: 'ddd MMM DD',
   agendaTimeFormat: 'LT',
-  agendaTimeRangeFormat: timeRangeFormat,
 }
 
 function fixUnit(unit) {
@@ -49,15 +41,23 @@ function fixUnit(unit) {
   }
   return datePart
 }
+const defFunctionFormats = {
+  selectRangeFormat: timeRangeFormat,
+  eventTimeRangeFormat: timeRangeFormat,
+  eventTimeRangeStartFormat: timeRangeStartFormat,
+  eventTimeRangeEndFormat: timeRangeEndFormat,
 
-export default function (moment) {
+  dayRangeHeaderFormat: weekRangeFormat,
+  agendaHeaderFormat: dateRangeFormat,
+
+  agendaTimeRangeFormat: timeRangeFormat,
+}
+export default function (moment, customFormats = defStringFormats) {
   const locale = (m, c) => (c ? m.locale(c) : m)
 
   function getTimezoneOffset(date) {
     // ensures this gets cast to timezone
-    return moment(date)
-      .toDate()
-      .getTimezoneOffset()
+    return moment(date).toDate().getTimezoneOffset()
   }
 
   function getDstOffset(start, end) {
@@ -343,7 +343,7 @@ export default function (moment) {
     const mtOffset = moment().utcOffset()
     return mtOffset > comparator ? 1 : 0
   }
-
+  const formats = { ...defFunctionFormats, ...customFormats }
   return new DateLocalizer({
     formats,
 

--- a/src/localizers/moment.js
+++ b/src/localizers/moment.js
@@ -18,7 +18,7 @@ const timeRangeStartFormat = ({ start }, culture, local) =>
 const timeRangeEndFormat = ({ end }, culture, local) =>
   ' – ' + local.format(end, 'LT', culture)
 
-const defStringFormats = {
+const defaultStringFormats = {
   dateFormat: 'DD',
   dayFormat: 'DD ddd',
   weekdayFormat: 'ddd',
@@ -41,7 +41,7 @@ function fixUnit(unit) {
   }
   return datePart
 }
-const defFunctionFormats = {
+const defaultFunctionFormats = {
   selectRangeFormat: timeRangeFormat,
   eventTimeRangeFormat: timeRangeFormat,
   eventTimeRangeStartFormat: timeRangeStartFormat,
@@ -52,7 +52,7 @@ const defFunctionFormats = {
 
   agendaTimeRangeFormat: timeRangeFormat,
 }
-export default function (moment, customFormats = defStringFormats) {
+export default function (moment, customFormats = defaultStringFormats) {
   const locale = (m, c) => (c ? m.locale(c) : m)
 
   function getTimezoneOffset(date) {
@@ -343,7 +343,7 @@ export default function (moment, customFormats = defStringFormats) {
     const mtOffset = moment().utcOffset()
     return mtOffset > comparator ? 1 : 0
   }
-  const formats = { ...defFunctionFormats, ...customFormats }
+  const formats = { ...defaultFunctionFormats, ...customFormats }
   return new DateLocalizer({
     formats,
 


### PR DESCRIPTION
I found an issue with date formats in react-big-calendar when i tried to use jalali calendar.
I defined the last _formats_ as a default value for **momentLocalizer** (_defaultStringFormats_ and _defaultFunctionFormats_). 
so when develper wants to change for example _dayHeaderFormat_ from 'dddd MMM DD' to ' @#MMM DD - dddd #@' can pass the customFormats parameter to **momentLocalizer** and it will be used in calendar instead of _defaultStringFormats_
