### PR TITLE
feat(event-height-precision): modification example

### DIFF
--- a/src/addons/dragAndDrop/common.js
+++ b/src/addons/dragAndDrop/common.js
@@ -38,7 +38,7 @@ export function eventTimes(event, accessors, localizer) {
 
   const isZeroDuration =
     localizer.eq(start, end, 'minutes') &&
-    localizer.diff(start, end, 'minutes') === 0
+    localizer.diff(start, end, 'seconds') === 0
   // make zero duration midnight events at least one day long
   if (isZeroDuration) end = localizer.add(end, 1, 'day')
   const duration = localizer.diff(start, end, 'milliseconds')

--- a/src/utils/TimeSlots.js
+++ b/src/utils/TimeSlots.js
@@ -45,7 +45,7 @@ export function getSlotMetrics({
 
   function positionFromDate(date) {
     const diff =
-      localizer.diff(start, date, 'minutes') +
+      localizer.diff(start, date, 'seconds') / 60 +
       localizer.getDstOffset(start, date)
     return Math.min(diff, totalMin)
   }

--- a/stories/props/eventHeightPrecision.mdx
+++ b/stories/props/eventHeightPrecision.mdx
@@ -1,0 +1,10 @@
+import { Canvas, Story } from '@storybook/addon-docs'
+
+# eventHeightPrecision
+
+- type: `"minutes"|"seconds"`
+- default: `"minutes"`
+
+An event's height will be rounded to the nearest `minute` or `second`.
+
+<Story id="props--event-height-precision" />

--- a/stories/props/eventHeightPrecision.stories.js
+++ b/stories/props/eventHeightPrecision.stories.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import moment from 'moment'
+import { Calendar, Views, momentLocalizer } from '../../src'
+import demoEvents from '../resources/events'
+import mdx from './eventHeightPrecision.mdx'
+
+const mLocalizer = momentLocalizer(moment)
+
+export default {
+  title: 'props',
+  component: Calendar,
+  argTypes: {
+    localizer: { control: { type: null } },
+    events: { control: { type: null } },
+    defaultView: {
+      control: {
+        type: null,
+      },
+    },
+  },
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+}
+
+const Template = (args) => (
+  <div className="height600">
+    <Calendar {...args} />
+  </div>
+)
+
+export const EventHeightPrecision = Template.bind({})
+EventHeightPrecision.storyName = 'eventHeightPrecision'
+EventHeightPrecision.args = {
+  defaultDate: new Date(2015, 3, 15),
+  defaultView: Views.DAY,
+  events: demoEvents,
+  localizer: mLocalizer,
+  step: 1,
+  timeslots: 5,
+  slotGroupPropGetter: () => ({ style: { minHeight: 240 } }),
+  scrollToTime: new Date(2015, 3, 15, 4, 55),
+}

--- a/stories/resources/events.js
+++ b/stories/resources/events.js
@@ -177,4 +177,28 @@ export default [
     start: new Date(2015, 3, 14, 18, 30, 0),
     end: new Date(2015, 3, 14, 20, 0, 0),
   },
+  {
+    id: 24,
+    title: 'Event (30s)',
+    start: new Date(2015, 3, 15, 4, 56, 45),
+    end: new Date(2015, 3, 15, 4, 57, 15),
+  },
+  {
+    id: 25,
+    title: 'Event (30s)',
+    start: new Date(2015, 3, 15, 4, 59, 0),
+    end: new Date(2015, 3, 15, 4, 59, 30),
+  },
+  {
+    id: 26,
+    title: 'Event (1min)',
+    start: new Date(2015, 3, 15, 5, 0, 0),
+    end: new Date(2015, 3, 15, 5, 1, 0),
+  },
+  {
+    id: 27,
+    title: 'Event (2min 40s)',
+    start: new Date(2015, 3, 15, 5, 2, 0),
+    end: new Date(2015, 3, 15, 5, 4, 40),
+  },
 ]


### PR DESCRIPTION
We have a use case where we need to display events that are shorter than a minute, and also events that don't start/end perfectly on a minute.

There should probably be a prop that changes the behavior. I propose `eventHeightPrecision` with possible values `"minutes"|"seconds"`, and default value `"minutes"` (current behavior). I'm not sure yet how to pass props this deep (any hint?), but I'll implement this if there is interest in the feature.

With this modification, the height of an event would be calculated from the seconds and not from the minutes. For now, the drag'n'drop actions (move and resize) would still snap to the slots.

The code I added makes 2 small modifications and [adds a story and some sample events](http://localhost:9002/?path=/story/props--event-height-precision) to document the change.
