### PR TITLE
docs: make "Docs" tab default

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -19,4 +19,5 @@ export const parameters = {
       ['Introduction', 'props'],
     ],
   },
+  viewMode: 'docs',
 }


### PR DESCRIPTION
The last comment in #2255 was about defaulting to "Docs" tab in storybook. 

This small change does just that.

Note that it doesn't work on the first page loaded (not an issue since "canvas" and "docs" are the same).
You may need to clear your browser's cache.
