### PR TITLE
fix: typo for prop titles

### DIFF
--- a/stories/props/API.stories.mdx
+++ b/stories/props/API.stories.mdx
@@ -823,7 +823,7 @@ Dates displayed in the gutter of the Agenda `view`
 
 Time only (not range) displayed in the gutter of the Agenda `view`
 
-## formats.agendaTimeRangeFormat
+### formats.agendaTimeRangeFormat
 
 - type: `function (range: Object {start: Date, end: Date}, culture: ?string, localizer: DateLocalizer) => string`
 - <LinkTo kind="props" story="formats-agenda-time-range-format">
@@ -832,7 +832,7 @@ Time only (not range) displayed in the gutter of the Agenda `view`
 
 Time range displayed in the gutter of the Agenda `view`
 
-# formats.eventTimeRangeFormat
+### formats.eventTimeRangeFormat
 
 - type: `function (range: Object {start: Date, end: Date}, culture: ?string, localizer: DateLocalizer) => string`
 - <LinkTo kind="props" story="formats-event-time-range-format">


### PR DESCRIPTION
Seems there are 2 prop titles with the wrong Markdown heading level.

Before:
<img width="930" alt="image" src="https://user-images.githubusercontent.com/1228449/200874838-991b3171-3de5-496d-90de-94eae9123c8a.png">

After:
<img width="803" alt="image" src="https://user-images.githubusercontent.com/1228449/200875906-1fe04879-493a-46c8-b26f-0b0ff9a05e30.png">
