### PR TITLE
fix: do not send undefined/null gutterRef to getWidth

### DIFF
--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -267,7 +267,9 @@ export default class TimeGrid extends Component {
     }
     this.measureGutterAnimationFrameRequest = window.requestAnimationFrame(
       () => {
-        const width = getWidth(this.gutterRef?.current)
+        const width = this.gutterRef?.current
+          ? getWidth(this.gutterRef.current)
+          : undefined
 
         if (width && this.state.gutterWidth !== width) {
           this.setState({ gutterWidth: width })


### PR DESCRIPTION
Bug fix: in scenarios where gutterRef is not defined specifically when using TimeGutterWrapper, we send null/undefined ref to getWidth function. getWidth function doesn't accept null/undefined argument. We already have a `?` check in the code just fixing it so it actually works.