### PR TITLE
Update WeekWrapper => handleMove | fix bug rtl dragging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-lib/
-dist/
 
 # Logs
 logs

--- a/src/addons/dragAndDrop/WeekWrapper.js
+++ b/src/addons/dragAndDrop/WeekWrapper.js
@@ -62,7 +62,8 @@ class WeekWrapper extends React.Component {
   handleMove = (point, bounds, draggedEvent) => {
     if (!pointInBox(bounds, point)) return this.reset()
     const event = this.context.draggable.dragAndDropAction.event || draggedEvent
-    const { accessors, slotMetrics, rtl, localizer } = this.props
+    const { accessors, slotMetrics, localizer } = this.props
+    const rtl = this.props.components.weekWrapper.contextType._defaultValue;
 
     const slot = getSlotAtX(bounds, point.x, rtl, slotMetrics.slots)
 


### PR DESCRIPTION
Fix bug dragging an event in the RTL month view calendar gets confused to the wrong side

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/jquense/react-big-calendar/blob/master/CONTRIBUTING.md) when submitting a pull request.
