### PR TITLE
Feature: End time after midnight

### DIFF
--- a/src/utils/TimeSlots.js
+++ b/src/utils/TimeSlots.js
@@ -10,6 +10,10 @@ export function getSlotMetrics({
   timeslots,
   localizer,
 }) {
+  if (localizer.lte(end, start)) {
+    end = localizer.add(end, 1, 'day')
+  }
+
   const key = getKey({ start, end, step, timeslots, localizer })
 
   // DST differences are handled inside the localizer

--- a/stories/demos/afterMidnight.stories.js
+++ b/stories/demos/afterMidnight.stories.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import moment from 'moment'
+import { Calendar, momentLocalizer } from '../../src'
+import AfterMidnight from './exampleCode/afterMidnight'
+
+export default {
+  title: 'Examples',
+  component: Calendar,
+  parameters: {
+    docs: {
+      page: null,
+    },
+  },
+}
+
+const localizer = momentLocalizer(moment)
+
+export function AfterMidnightStory() {
+  return <AfterMidnight localizer={localizer} />
+}
+AfterMidnightStory.storyName = 'End day after midnight'

--- a/stories/demos/exampleCode/afterMidnight.js
+++ b/stories/demos/exampleCode/afterMidnight.js
@@ -1,0 +1,68 @@
+import React, { Fragment, useCallback, useState } from 'react'
+import PropTypes from 'prop-types'
+import moment from 'moment'
+import {
+  Calendar,
+  Views,
+  DateLocalizer,
+  momentLocalizer,
+} from 'react-big-calendar'
+import DemoLink from '../../DemoLink.component'
+import events from '../../resources/events'
+import * as dates from '../../../src/utils/dates'
+
+const mLocalizer = momentLocalizer(moment)
+
+const defaultDate = dates.startOf(new Date(2015, 3, 14))
+
+const calendarProps = {
+  defaultDate,
+  min: dates.add(defaultDate, 12, 'hours'),
+  max: dates.add(defaultDate, 4, 'hours'),
+  views: Object.keys(Views).map((k) => Views[k]),
+  defaultView: 'day',
+}
+
+export default function AfterMidnight({ localizer = mLocalizer, ...props }) {
+  const [myEvents, setEvents] = useState(() =>
+    events.map((event) => ({
+      ...event,
+      start: dates.add(event.start, 6, 'hours'),
+      end: dates.add(event.end, 6, 'hours'),
+    }))
+  )
+
+  const handleSelectSlot = useCallback(
+    ({ start, end }) => {
+      const title = window.prompt('New Event Name')
+      if (title) {
+        setEvents((prev) => [...prev, { start, end, title }])
+      }
+    },
+    [setEvents]
+  )
+
+  return (
+    <Fragment>
+      <DemoLink fileName="afterMidnight">
+        <strong>
+          If your events often span past midnight, you can set max time to show
+          night hours in the previous day's column.
+        </strong>
+      </DemoLink>
+      <div className="height600" {...props}>
+        <Calendar
+          {...calendarProps}
+          events={myEvents}
+          onSelectSlot={handleSelectSlot}
+          localizer={localizer}
+          step={60}
+          selectable
+        />
+      </div>
+    </Fragment>
+  )
+}
+AfterMidnight.propTypes = {
+  localizer: PropTypes.instanceOf(DateLocalizer),
+}


### PR DESCRIPTION
This pull requests allows day columns to wrap over to the following day if the Calendar's _max_ prop is set to a time before _min_. This is useful if you got events that commonly span past midnight. Another edge case this resolves is that "min = max = 00:00" allows you to create events that end at 00:00 the following day instead of 23:59, which seems to be the current limit.

![image](https://user-images.githubusercontent.com/1138686/209799665-d4d89670-2567-4beb-9cdd-8b3ea2a21bbf.png)
