### PR TITLE
docs: add slack invite links

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,6 @@ SASS implementation provides a `variables` file containing color and sizing vari
 update to fit your application. _Note:_ Changing and/or overriding styles can cause rendering issues with your
 Big Calendar. Carefully test each change accordingly.
 
-## Join us on Reactiflux Discord
+## Join The Community
 
-Join us on [Reactiflux Discord](https://discord.gg/reactiflux) community under the channel #libraries if you have any questions.
+Help us improve Big Calendar! Join us on [Slack](https://join.slack.com/t/bigcalendar/shared_invite/zt-1ml1j99af-qIvqOfosMog1W7WxM0~j2Q).

--- a/stories/AboutBigCalendar.stories.mdx
+++ b/stories/AboutBigCalendar.stories.mdx
@@ -67,3 +67,7 @@ We have provided a number of <LinkTo kind="examples">Examples</LinkTo> within th
 The documentation 'Canvas' tab, at the top of the page, will show you the component example for that specific piece of documentation. While in the 'Canvas' you may also have interactive controls in the 'Controls' panel, allowing you to play with a prop's different values.
 
 The 'Docs' tab will contain additional information, special case scenarios, and the rendered example. Most of these examples contain a 'Show code' button (bottom right), or even a special link at the top to 'View Example Source Code'.
+
+## Join the Community
+
+Help us improve Big Calendar! Join us on [Slack](https://join.slack.com/t/bigcalendar/shared_invite/zt-1ml1j99af-qIvqOfosMog1W7WxM0~j2Q).


### PR DESCRIPTION
Remove the (mostly defunct) Discord links from documentation, replacing with link to invite to new Slack workspace.
