### PR TITLE
fix: rounding behavior in Luxon localizer

### DIFF
--- a/src/localizers/luxon.js
+++ b/src/localizers/luxon.js
@@ -239,7 +239,7 @@ export default function (DateTime, { firstDayOfWeek = 7 } = {}) {
     // don't use 'defineComparators' here, as we don't want to mutate the values
     const dtA = DateTime.fromJSDate(a)
     const dtB = DateTime.fromJSDate(b)
-    return Math.round(
+    return Math.floor(
       dtB.diff(dtA, datePart, { conversionAccuracy: 'longterm' }).toObject()[
         datePart
       ]


### PR DESCRIPTION
Closes #2361

Round down the date difference returned in the `diff` function of the luxon localizer to the nearest whole number, aligning the behavior with other localizers.

For example, the `momentLocalizer`  uses the moment diff, which truncates the result to zero decimal places [by default](https://momentjscom.readthedocs.io/en/latest/moment/04-displaying/07-difference): 
https://github.com/jquense/react-big-calendar/blob/52a6d1f3d9ac047d9f1fcf2f2081a1c2f1749781/src/localizers/moment.js#L202


Before:

![image](https://user-images.githubusercontent.com/21250621/216188697-35b51f1c-0cff-419b-a636-c5ef8ece19e5.png)


Now:

![image](https://user-images.githubusercontent.com/21250621/216188743-3dc1a3f2-57db-4ca5-b849-70ad20d3c399.png)
