### PR TITLE
fix: event overlap other event #2348

### DIFF
--- a/src/TimeGridEvent.js
+++ b/src/TimeGridEvent.js
@@ -31,7 +31,7 @@ function TimeGridEvent(props) {
 
   let userProps = getters.eventProp(event, start, end, selected)
 
-  let { height, top, width, xOffset } = style
+  let { height, top, width, xOffset, zIndex } = style
   const inner = [
     <div key="1" className="rbc-event-label">
       {label}
@@ -52,6 +52,7 @@ function TimeGridEvent(props) {
       }
     : {
         ...userProps.style,
+        zIndex: zIndex,
         top: stringifyPercent(top),
         width: stringifyPercent(width),
         height: stringifyPercent(height),

--- a/src/utils/layout-algorithms/overlap.js
+++ b/src/utils/layout-algorithms/overlap.js
@@ -77,6 +77,16 @@ class Event {
     const index = leaves.indexOf(this) + 1
     return xOffset + index * _width
   }
+
+  get zIndex() {
+    if (this.rows) return 1
+
+    if (this.leaves) return 2
+
+    const { leaves } = this.row
+    const index = leaves.indexOf(this) + this.row.zIndex
+    return index
+  }
 }
 
 /**
@@ -87,7 +97,9 @@ function onSameRow(a, b, minimumStartDifference) {
     // Occupies the same start slot.
     Math.abs(b.start - a.start) < minimumStartDifference ||
     // A's start slot overlaps with b's end slot.
-    (b.start > a.start && b.start < a.end)
+    (b.start > a.start && b.start < a.end) ||
+    // B's start slot overlaps with a's end slot.
+    (a.start > b.start && a.start < b.end)
   )
 }
 
@@ -186,6 +198,7 @@ export default function getStyledEvents({
       height: event.height,
       width: event.width,
       xOffset: Math.max(0, event.xOffset),
+      zIndex: event.zIndex,
     },
   }))
 }


### PR DESCRIPTION
This is a PR to fix [issue #2348.](https://github.com/jquense/react-big-calendar/issues/2348)

1. Added the case where B's start slot covers A's end slot to the onSameRow(in src/utils/layout-algorithms/overlap.js) function.
2. Added ordered z-index values to leaves belonging to a row.

I'm currently using that commit version in production.
However, I am concerned that the addition of the z-index will have a negative impact on other parts.

Thank you.