### PR TITLE
fix: 1px misalignment

### DIFF
--- a/src/TimeGridHeader.js
+++ b/src/TimeGridHeader.js
@@ -49,7 +49,7 @@ class TimeGridHeader extends React.Component {
             <button
               type="button"
               className="rbc-button-link"
-              onClick={e => this.handleHeaderClick(date, drilldownView, e)}
+              onClick={(e) => this.handleHeaderClick(date, drilldownView, e)}
             >
               {header}
             </button>
@@ -129,7 +129,7 @@ class TimeGridHeader extends React.Component {
 
     let style = {}
     if (isOverflowing) {
-      style[rtl ? 'marginLeft' : 'marginRight'] = `${scrollbarSize()}px`
+      style[rtl ? 'marginLeft' : 'marginRight'] = `${scrollbarSize() - 1}px`
     }
 
     const groupedEvents = resources.groupEvents(events)


### PR DESCRIPTION
between TimeGridHeader and scrollbar
on week and work_week views

please take a look at the example http://jquense.github.io/react-big-calendar/examples/index.html?path=/docs/examples--example-9

<img width="1206" alt="Screenshot 2023-02-15 at 16 09 51" src="https://user-images.githubusercontent.com/1488195/219030208-0f912ed3-aaa9-47b7-ba7a-f39d70512ee8.png">

It is a little bit nicer if header border looks like a part of the scrollbar

<img width="633" alt="Screenshot 2023-02-15 at 16 44 44" src="https://user-images.githubusercontent.com/1488195/219030700-4410348b-00eb-4668-82a6-49d48b4b47b1.png">


