### PR TITLE
fix(moment): wrong time on the day when DST changes

### DIFF
--- a/src/localizers/moment.js
+++ b/src/localizers/moment.js
@@ -60,8 +60,10 @@ export default function (moment) {
 
   function getDstOffset(start, end) {
     // convert to moment, in case
-    const st = moment(start)
-    const ed = moment(end)
+    // Calculate the offset in the timezone of the Events (local)
+    // not in the timezone of the calendar (moment.tz)
+    const st = moment(start).local()
+    const ed = moment(end).local()
     // if not using moment timezone
     if (!moment.tz) {
       return st.toDate().getTimezoneOffset() - ed.toDate().getTimezoneOffset()

--- a/stories/resources/events.js
+++ b/stories/resources/events.js
@@ -177,4 +177,28 @@ export default [
     start: new Date(2015, 3, 14, 18, 30, 0),
     end: new Date(2015, 3, 14, 20, 0, 0),
   },
+  {
+    id: 24,
+    title: 'DST ends on this day (Europe)',
+    start: new Date(2022, 9, 30, 0, 0, 0),
+    end: new Date(2022, 9, 30, 4, 30, 0),
+  },
+  {
+    id: 25,
+    title: 'DST ends on this day (America)',
+    start: new Date(2022, 10, 6, 0, 0, 0),
+    end: new Date(2022, 10, 6, 4, 30, 0),
+  },
+  {
+    id: 26,
+    title: 'DST starts on this day (America)',
+    start: new Date(2023, 2, 12, 0, 0, 0),
+    end: new Date(2023, 2, 12, 4, 30, 0),
+  },
+  {
+    id: 27,
+    title: 'DST starts on this day (Europe)',
+    start: new Date(2023, 2, 26, 0, 0, 0),
+    end: new Date(2023, 2, 26, 4, 30, 0),
+  },
 ]


### PR DESCRIPTION
This seems to fix #2296 for me, but only for the `moment` localizer. Still have to find a fix for `luxon`.

I think the problem might come from this: https://day.js.org/docs/en/plugin/timezone#differences-to-moment

@cutterbl can you check that this doesn't break something else on your side?
