### PR TITLE
Moving events lasting less than a minute

### DIFF
--- a/src/addons/dragAndDrop/common.js
+++ b/src/addons/dragAndDrop/common.js
@@ -38,7 +38,7 @@ export function eventTimes(event, accessors, localizer) {
 
   const isZeroDuration =
     localizer.eq(start, end, 'minutes') &&
-    localizer.diff(start, end, 'minutes') === 0
+    localizer.diff(start, end, 'seconds') === 0
   // make zero duration midnight events at least one day long
   if (isZeroDuration) end = localizer.add(end, 1, 'day')
   const duration = localizer.diff(start, end, 'milliseconds')


### PR DESCRIPTION
Fix issue #2314 
When working with events that can have only a few seconds difference between end and start, dragging is visually broken because the end date is set the next day.
