### PR TITLE
docs: add resourceId to onSelectSlot documentation

### DIFF
--- a/stories/props/onSelectSlot.mdx
+++ b/stories/props/onSelectSlot.mdx
@@ -16,6 +16,7 @@ _Things To Know:_ When you 'doubleClick', both 'click' and 'doubleClick' will fi
   end: Date,
   slots: Array<Date>,
   action: 'select' | 'click' | 'doubleClick',
+  resourceId: ?number, // only if the calendar is resource view
   bounds: ?{
     // For "select" action
     x: number,


### PR DESCRIPTION
Update the `onSelectSlot` documentation to include the `resourceId`
