### PR TITLE
Fix popup position when there's no enough space to its right

### DIFF
--- a/src/Popup.js
+++ b/src/Popup.js
@@ -26,7 +26,10 @@ function getPosition({ target, offset, container, box }) {
   const right = left + bWidth
   const { x, y } = offset
   const topOffset = bottom > viewBottom ? top - bHeight - y : top + y + height
-  const leftOffset = right > viewRight ? left + x - bWidth + width : left + x
+  const leftOffset =
+    right > viewRight && left + x - bWidth + width >= 0
+      ? left + x - bWidth + width
+      : left + x
 
   return {
     topOffset,


### PR DESCRIPTION
# Problem:
When an event title is too long, the `show more` popup may be positioned off screen with the `left` offset being set to a negative value.
Ideally the event title should be concise but I think it's still worth fixing the underlying issue here.

# When there's enough space to its right:
![image](https://github.com/jquense/react-big-calendar/assets/22125018/e4e56767-db12-4596-8da2-5f59674aada9)

# When there's no enough space to its right:
![image](https://github.com/jquense/react-big-calendar/assets/22125018/1fce2731-4a8a-4ce4-b21f-0e01ac7e07e1)


# The fix:
Add another condition check to make sure `left` is never negative.

# How it looks like after the fix when there's no enough space to its right:
![image](https://github.com/jquense/react-big-calendar/assets/22125018/5921b939-4089-4f9a-9231-166fdaeab368)
