### PR TITLE
fix: time grid header component margin is not recalculated when the s…

### DIFF
--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import clsx from 'clsx'
 import * as animationFrame from 'dom-helpers/animationFrame'
 import memoize from 'memoize-one'
+import scrollbarSize from 'dom-helpers/scrollbarSize'
 
 import DayColumn from './DayColumn'
 import TimeGutter from './TimeGutter'
@@ -21,7 +22,11 @@ export default class TimeGrid extends Component {
   constructor(props) {
     super(props)
 
-    this.state = { gutterWidth: undefined, isOverflowing: null }
+    this.state = {
+      gutterWidth: undefined,
+      isOverflowing: null,
+      scrollBarSize: scrollbarSize(),
+    }
 
     this.scrollRef = React.createRef()
     this.contentRef = React.createRef()
@@ -44,6 +49,12 @@ export default class TimeGrid extends Component {
     this.applyScroll()
 
     window.addEventListener('resize', this.handleResize)
+
+    const resizeObserver = new ResizeObserver(this.getScrollBarSize)
+
+    if (this.contentRef && this.contentRef.current) {
+      resizeObserver.observe(this.contentRef.current)
+    }
   }
 
   handleScroll = (e) => {
@@ -275,6 +286,7 @@ export default class TimeGrid extends Component {
           onDrillDown={this.props.onDrillDown}
           getDrilldownView={this.props.getDrilldownView}
           resizable={resizable}
+          scrollBarSize={this.state.scrollBarSize}
         />
         {this.props.popup && this.renderOverlay()}
         <div
@@ -399,6 +411,13 @@ export default class TimeGrid extends Component {
       this.setState({ isOverflowing }, () => {
         this._updatingOverflow = false
       })
+    }
+  }
+
+  getScrollBarSize = () => {
+    const scrollBarSize = scrollbarSize(true)
+    if (this.state.scrollBarSize !== scrollBarSize) {
+      this.setState({ scrollBarSize })
     }
   }
 

--- a/src/TimeGridHeader.js
+++ b/src/TimeGridHeader.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types'
 import clsx from 'clsx'
-import scrollbarSize from 'dom-helpers/scrollbarSize'
 import React from 'react'
 
 import DateContentRow from './DateContentRow'
@@ -128,11 +127,12 @@ class TimeGridHeader extends React.Component {
         resourceHeader: ResourceHeaderComponent = ResourceHeader,
       },
       resizable,
+      scrollBarSize,
     } = this.props
 
     let style = {}
     if (isOverflowing) {
-      style[rtl ? 'marginLeft' : 'marginRight'] = `${scrollbarSize() - 1}px`
+      style[rtl ? 'marginLeft' : 'marginRight'] = `${scrollBarSize - 1}px`
     }
 
     const groupedEvents = resources.groupEvents(events)
@@ -212,6 +212,7 @@ TimeGridHeader.propTypes = {
   rtl: PropTypes.bool,
   resizable: PropTypes.bool,
   width: PropTypes.number,
+  scrollBarSize: PropTypes.number,
 
   localizer: PropTypes.object.isRequired,
   accessors: PropTypes.object.isRequired,


### PR DESCRIPTION
Fix for issue [#2402](https://github.com/jquense/react-big-calendar/issues/2402)

**Issue:**
https://www.loom.com/share/428411cb7d0144aabe921946c311acd0
When the scroll settings is changed on macOS, the margin calculation for `TimeGridHeader` is not recalculated which create a misalignment between the header and the content of the `TimeGrid`.

**Solution:**
 Add an observer for the content, when the scroll bar is hidden/displayed we calculate the scroll bar width as a state in the `TimeGrid` component and move it as a prop to `TimeGridHeader`.
