### PR TITLE
Fix bug - Dragging an event in the RTL month view calendar gets confused to the wrong side

### DIFF
--- a/src/DateContentRow.js
+++ b/src/DateContentRow.js
@@ -181,7 +181,7 @@ class DateContentRow extends React.Component {
             </div>
           )}
           <ScrollableWeekComponent>
-            <WeekWrapper isAllDay={isAllDay} {...eventRowProps}>
+            <WeekWrapper isAllDay={isAllDay} {...eventRowProps} rtl={this.props.rtl}>
               {levels.map((segs, idx) => (
                 <EventRow key={idx} segments={segs} {...eventRowProps} />
               ))}


### PR DESCRIPTION
Fix issue #2310 and #1801

**Issue:** 
https://drive.google.com/file/d/1kKL80YCJLrz6q0Y1GJeWzlwNgkccJ-OA/view
When dragging an event in the RTL month view calendar, the calendar gets confused and the event goes in the opposite direction, this also happens in the week view at the allDay section.

**Solution:**
I have forwarded the `rtl` params to the `WeekWrapper`.
This is a fix specifically for dragAndDrop and doesn't solve all of the RTL problems.
