### PR TITLE
fix: Keep events sorted in one row for no-overlap algorithm

### DIFF
--- a/src/utils/layout-algorithms/no-overlap.js
+++ b/src/utils/layout-algorithms/no-overlap.js
@@ -28,8 +28,25 @@ export default function ({
   styledEvents.sort((a, b) => {
     a = a.style
     b = b.style
-    if (a.top !== b.top) return a.top > b.top ? 1 : -1
-    else return a.top + a.height < b.top + b.height ? 1 : -1
+    if (a.top !== b.top) {
+      if (a.top > b.top) {
+        return 1;
+      }
+      if (a.top < b.top) {
+        return -1;
+      }
+      return 0;
+    } else {
+      const valueA = a.top + a.height;
+      const valueB = b.top + b.height;
+      if (valueA > valueB) {
+        return 1;
+      }
+      if (valueA < valueB) {
+        return -1;
+      }
+      return 0;
+    }
   })
 
   for (let i = 0; i < styledEvents.length; ++i) {


### PR DESCRIPTION
Currently no-overlap algorithm changes events sorting in one row even if it shouldn't be. Fix for keeping sorting

Sorted events before applying no-overlap
<img width="545" alt="Screenshot 2023-11-16 at 09 26 57" src="https://github.com/jquense/react-big-calendar/assets/15867703/e4ab6653-50e2-492c-825d-ccba5e45e4ea">

Events order without fix (event2, event1)
<img width="1343" alt="Screenshot 2023-11-16 at 09 26 36" src="https://github.com/jquense/react-big-calendar/assets/15867703/3d213c44-334a-4bbc-bfad-7af60107111b">

Events order with fix (event1, event2)
<img width="1347" alt="Screenshot 2023-11-16 at 09 26 02" src="https://github.com/jquense/react-big-calendar/assets/15867703/535d951f-a267-46c2-96c6-ef6b8e4de5c4">

