### PR TITLE
Fix dragAndDrop EventWrapper.js error: cannot add property 'X', object is not extensible

### DIFF
--- a/src/addons/dragAndDrop/EventWrapper.js
+++ b/src/addons/dragAndDrop/EventWrapper.js
@@ -47,7 +47,7 @@ class EventWrapper extends React.Component {
       .getAttribute('class')
       ?.includes('rbc-addons-dnd-resize')
     if (!isResizeHandle) {
-      let extendedEvent = this.props.event
+      let extendedEvent = JSON.parse(JSON.stringify(this.props.event))
       extendedEvent.sourceResource = this.props.resource
       this.context.draggable.onBeginAction(this.props.event, 'move')
     }

--- a/src/addons/dragAndDrop/EventWrapper.js
+++ b/src/addons/dragAndDrop/EventWrapper.js
@@ -47,7 +47,7 @@ class EventWrapper extends React.Component {
       .getAttribute('class')
       ?.includes('rbc-addons-dnd-resize')
     if (!isResizeHandle) {
-      let extendedEvent = JSON.parse(JSON.stringify(this.props.event))
+      let extendedEvent = {...this.props.event}
       extendedEvent.sourceResource = this.props.resource
       this.context.draggable.onBeginAction(this.props.event, 'move')
     }


### PR DESCRIPTION
Fix for error: cannot add property 'X', object is not extensible

Above console error appears when using the Resource Drag and Drop feature of react big calendar to move events.  I narrowed the issue down to this code in the addons/dragandDrop/EventWrapper.js:
let extendedEvent = this.props.event

Per the [linked discussion on Stack Overflow](https://stackoverflow.com/questions/55567386/react-cannot-add-property-x-object-is-not-extensible), it is not possible to modify this.props directly. The solution is to create a copy of the props using JSON.parse() and JSON.stringify()

Thus the modified code that I have gotten working without error is:
let extendedEvent = JSON.parse(JSON.stringify(this.props.event))