### PR TITLE
fix: add isBackgroundEvent to onSelectEvent event obj

### DIFF
--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -241,7 +241,16 @@ class DayColumn extends React.Component {
           resource={this.props.resource}
           selected={isSelected(event, selected)}
           onClick={(e) =>
-            this._select({ ...event, sourceResource: this.props.resource }, e)
+            this._select(
+              {
+                ...event,
+                ...(this.props.resource && {
+                  sourceResource: this.props.resource,
+                }),
+                ...(isBackgroundEvent && { isBackgroundEvent: true }),
+              },
+              e
+            )
           }
           onDoubleClick={(e) => this._doubleClick(event, e)}
           isBackgroundEvent={isBackgroundEvent}


### PR DESCRIPTION
Adds `isBackgroundEvent` flag to 'event' objects passed to `onSelectEvent`
