### PR TITLE
feat: add screen reader support to date headers

### DIFF
--- a/src/DateHeader.js
+++ b/src/DateHeader.js
@@ -1,18 +1,18 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-const DateHeader = ({ label, localizer, date, drilldownView, onDrillDown }) => {
-  const renderLabel = () => (
-    <>
-      <span aria-hidden="true">{label}</span>
-      <span className="rbc-sr-only">
-        {localizer.format(date, 'ddd MMM DD YYYY')}
-      </span>
-    </>
-  )
+const DateHeaderLabel = (label, localizer, date) => (
+  <>
+    <span aria-hidden="true">{label}</span>
+    <span className="rbc-sr-only">
+      {localizer.format(date, 'ddd MMM DD YYYY')}
+    </span>
+  </>
+)
 
+const DateHeader = ({ label, localizer, date, drilldownView, onDrillDown }) => {
   if (!drilldownView) {
-    return renderLabel()
+    return <DateHeaderLabel label={label} date={date} localizer={localizer} />
   }
 
   return (
@@ -22,7 +22,7 @@ const DateHeader = ({ label, localizer, date, drilldownView, onDrillDown }) => {
       onClick={onDrillDown}
       role="cell"
     >
-      {renderLabel()}
+      <DateHeaderLabel label={label} date={date} localizer={localizer} />
     </button>
   )
 }

--- a/src/DateHeader.js
+++ b/src/DateHeader.js
@@ -1,9 +1,18 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-const DateHeader = ({ label, drilldownView, onDrillDown }) => {
+const DateHeader = ({ label, localizer, date, drilldownView, onDrillDown }) => {
+  const renderLabel = () => (
+    <>
+      <span aria-hidden="true">{label}</span>
+      <span className="rbc-sr-only">
+        {localizer.format(date, 'ddd MMM DD YYYY')}
+      </span>
+    </>
+  )
+
   if (!drilldownView) {
-    return <span>{label}</span>
+    return renderLabel()
   }
 
   return (
@@ -13,13 +22,14 @@ const DateHeader = ({ label, drilldownView, onDrillDown }) => {
       onClick={onDrillDown}
       role="cell"
     >
-      {label}
+      {renderLabel()}
     </button>
   )
 }
 
 DateHeader.propTypes = {
   label: PropTypes.node,
+  localizer: PropTypes.object.isRequired,
   date: PropTypes.instanceOf(Date),
   drilldownView: PropTypes.string,
   onDrillDown: PropTypes.func,

--- a/src/Month.js
+++ b/src/Month.js
@@ -178,6 +178,7 @@ class MonthView extends React.Component {
       >
         <DateHeaderComponent
           label={label}
+          localizer={localizer}
           date={date}
           drilldownView={drilldownView}
           isOffRange={isOffRange}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -111,6 +111,17 @@
   }
 }
 
+.rbc-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
 .rbc-today {
   background-color: $today-highlight-bg;
 }


### PR DESCRIPTION
Adds screen reader support to date headers, as discussed in #2488.
