### PR TITLE
feat: showMore message add event info

### DIFF
--- a/src/EventEndingRow.js
+++ b/src/EventEndingRow.js
@@ -7,7 +7,7 @@ import range from 'lodash/range'
 
 let isSegmentInSlot = (seg, slot) => seg.left <= slot && seg.right >= slot
 let eventsInSlot = (segments, slot) =>
-  segments.filter((seg) => isSegmentInSlot(seg, slot)).length
+  segments.filter((seg) => isSegmentInSlot(seg, slot)).map((seg) => seg.event)
 
 class EventEndingRow extends React.Component {
   render() {
@@ -68,16 +68,17 @@ class EventEndingRow extends React.Component {
     let { segments } = this.props
 
     return range(slot, slot + span).every((s) => {
-      let count = eventsInSlot(segments, s)
+      const count = eventsInSlot(segments, s).length
 
       return count === 1
     })
   }
 
   renderShowMore(segments, slot) {
-    let { localizer } = this.props
-    let count = eventsInSlot(segments, slot)
-
+    let { localizer, slotMetrics } = this.props
+    const events = slotMetrics.getEventsForSlot(slot)
+    const remainingEvents = eventsInSlot(segments, slot)
+    const count = remainingEvents.length
     return count ? (
       <button
         type="button"
@@ -85,7 +86,7 @@ class EventEndingRow extends React.Component {
         className={clsx('rbc-button-link', 'rbc-show-more')}
         onClick={(e) => this.showMore(slot, e)}
       >
-        {localizer.messages.showMore(count, slot)}
+        {localizer.messages.showMore(count, remainingEvents, events)}
       </button>
     ) : (
       false

--- a/src/EventEndingRow.js
+++ b/src/EventEndingRow.js
@@ -85,7 +85,7 @@ class EventEndingRow extends React.Component {
         className={clsx('rbc-button-link', 'rbc-show-more')}
         onClick={(e) => this.showMore(slot, e)}
       >
-        {localizer.messages.showMore(count)}
+        {localizer.messages.showMore(count, slot)}
       </button>
     ) : (
       false

--- a/stories/props/messages.mdx
+++ b/stories/props/messages.mdx
@@ -27,8 +27,12 @@ defualts
   agenda: 'Agenda',
 
   noEventsInRange: 'There are no events in this range.',
-
-  showMore: total => `+${total} more`,
+  /**
+   * params {total} count of remaining events 
+   * params {remainingEvents} remaining events 
+   * params {events} all events in day
+   */
+  showMore: (total, remainingEvents, events) => `+${total} más`,
 }
 ```
 


### PR DESCRIPTION
![image](https://github.com/jquense/react-big-calendar/assets/21307445/0f88f7ed-2f8b-4e4b-85cb-2781fe3cdf76)
Sometimes, we need to incorporate additional event information into texts that display more items. Therefore, we have added the input of event parameters.