### PR TITLE
fix: changed flex-direction for rbc-toolbar mobile

### DIFF
--- a/src/sass/toolbar.scss
+++ b/src/sass/toolbar.scss
@@ -104,3 +104,9 @@ $active-border: darken($btn-border, 12%);
     margin-left: 10px;
   }
 }
+
+@media (max-width: 767px) {
+  .rbc-toolbar {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
This request is to add in a css change that helps fix toolbar wrapping when the display is too small. This issue was brought up [here - #1699](https://github.com/jquense/react-big-calendar/issues/1699). This should help cleanup some undesirable toolbar displays for mobile users. 

Bellow are some screenshots that show the issue I was describing. On mobile devices, if the selected date is too long then it will get wrapped beneath the "Today, Back, Next" buttons. This change will stack these three elements in a column for smaller display widths which helps it to look cleaner and prevents the button positions from shifting while scrolling through dates using the "next" button. Essentially, it will make all cases look like the second picture regardless of date length.

![image](https://github.com/jquense/react-big-calendar/assets/159053844/e160793d-242b-4249-b1e2-fdad53229b11)

![image](https://github.com/jquense/react-big-calendar/assets/159053844/6c4225c6-afc9-4215-b8ae-cb780ec06be5)

