### PR TITLE
fix(ARIA): remove tabindex

### DIFF
--- a/src/EventCell.js
+++ b/src/EventCell.js
@@ -62,7 +62,6 @@ class EventCell extends React.Component {
       <EventWrapper {...this.props} type="date">
         <div
           {...props}
-          tabIndex={0}
           style={{ ...userProps.style, ...style }}
           className={clsx('rbc-event', className, userProps.className, {
             'rbc-selected': selected,


### PR DESCRIPTION
The tabindex, applied to the event div, creates invalid ARIA component nesting

#2498