### PR TITLE
fix overlapping background events, fixes #2452

### DIFF
--- a/src/TimeGridEvent.js
+++ b/src/TimeGridEvent.js
@@ -47,7 +47,7 @@ function TimeGridEvent(props) {
         top: stringifyPercent(top),
         height: stringifyPercent(height),
         // Adding 10px to take events container right margin into account
-        width: `calc(${width} + 10px)`,
+        width: `calc(${stringifyPercent(width)} + 10px)`,
         [rtl ? 'right' : 'left']: stringifyPercent(Math.max(0, xOffset)),
       }
     : {

--- a/src/TimeGridEvent.js
+++ b/src/TimeGridEvent.js
@@ -31,7 +31,6 @@ function TimeGridEvent(props) {
 
   let userProps = getters.eventProp(event, start, end, selected)
 
-  let { height, top, width, xOffset } = style
   const inner = [
     <div key="1" className="rbc-event-label">
       {label}
@@ -41,22 +40,15 @@ function TimeGridEvent(props) {
     </div>,
   ]
 
-  const eventStyle = isBackgroundEvent
-    ? {
-        ...userProps.style,
-        top: stringifyPercent(top),
-        height: stringifyPercent(height),
-        // Adding 10px to take events container right margin into account
-        width: `calc(${stringifyPercent(width)} + 10px)`,
-        [rtl ? 'right' : 'left']: stringifyPercent(xOffset),
-      }
-    : {
-        ...userProps.style,
-        top: stringifyPercent(top),
-        width: stringifyPercent(width),
-        height: stringifyPercent(height),
-        [rtl ? 'right' : 'left']: stringifyPercent(xOffset),
-      }
+  const { height, top, width, xOffset } = style
+
+  const eventStyle = {
+    ...userProps.style,
+    top: stringifyPercent(top),
+    height: stringifyPercent(height),
+    width: stringifyPercent(width),
+    [rtl ? 'right' : 'left']: stringifyPercent(xOffset),
+  }
 
   return (
     <EventWrapper type="time" {...props}>

--- a/src/TimeGridEvent.js
+++ b/src/TimeGridEvent.js
@@ -48,7 +48,7 @@ function TimeGridEvent(props) {
         height: stringifyPercent(height),
         // Adding 10px to take events container right margin into account
         width: `calc(${stringifyPercent(width)} + 10px)`,
-        [rtl ? 'right' : 'left']: stringifyPercent(Math.max(0, xOffset)),
+        [rtl ? 'right' : 'left']: stringifyPercent(xOffset),
       }
     : {
         ...userProps.style,

--- a/stories/Layout.stories.js
+++ b/stories/Layout.stories.js
@@ -258,3 +258,55 @@ OverlappingBackgroundEventsOverlap.args = {
     },
   ],
 }
+
+export const OverlappingBackgroundEventsNoOverlap = Template.bind({})
+OverlappingBackgroundEventsNoOverlap.storyName =
+  "Overlapping Background Events - 'no-overlap'"
+OverlappingBackgroundEventsNoOverlap.args = {
+  defaultDate: new Date(2016, 11, 3),
+  dayLayoutAlgorithm: 'no-overlap',
+  defaultView: Views.WEEK,
+  scrollToTime: new Date(2016, 11, 1, 7, 0),
+  backgroundEvents: [
+    {
+      title: 'First Event',
+      start: new Date(2016, 10, 28, 10, 30),
+      end: new Date(2016, 10, 28, 18, 0),
+    },
+    {
+      title: 'Second Event',
+      start: new Date(2016, 10, 28, 12, 0),
+      end: new Date(2016, 10, 28, 16, 30),
+    },
+    {
+      title: 'Third Event',
+      start: new Date(2016, 10, 29, 8, 0),
+      end: new Date(2016, 10, 29, 21, 0),
+    },
+    {
+      title: 'Fourth Event',
+      start: new Date(2016, 10, 29, 9, 30),
+      end: new Date(2016, 10, 29, 19, 30),
+    },
+    {
+      title: 'Fifth Event',
+      start: new Date(2016, 10, 29, 11, 0),
+      end: new Date(2016, 10, 29, 18, 0),
+    },
+    {
+      title: 'Sixth Event',
+      start: new Date(2016, 11, 1, 9, 0),
+      end: new Date(2016, 11, 1, 14, 0),
+    },
+    {
+      title: 'Seventh Event',
+      start: new Date(2016, 11, 1, 11, 0),
+      end: new Date(2016, 11, 1, 16, 0),
+    },
+    {
+      title: 'Eighth Event',
+      start: new Date(2016, 11, 1, 13, 0),
+      end: new Date(2016, 11, 1, 18, 0),
+    },
+  ],
+}

--- a/stories/Layout.stories.js
+++ b/stories/Layout.stories.js
@@ -206,3 +206,55 @@ export const ZeroDurationOverlap = () => {
     />
   )
 }
+
+export const OverlappingBackgroundEventsOverlap = Template.bind({})
+OverlappingBackgroundEventsOverlap.storyName =
+  "Overlapping Background Events - 'overlap'"
+OverlappingBackgroundEventsOverlap.args = {
+  defaultDate: new Date(2016, 11, 3),
+  dayLayoutAlgorithm: 'overlap',
+  defaultView: Views.WEEK,
+  scrollToTime: new Date(2016, 11, 1, 7, 0),
+  backgroundEvents: [
+    {
+      title: 'First Event',
+      start: new Date(2016, 10, 28, 10, 30),
+      end: new Date(2016, 10, 28, 18, 0),
+    },
+    {
+      title: 'Second Event',
+      start: new Date(2016, 10, 28, 12, 0),
+      end: new Date(2016, 10, 28, 16, 30),
+    },
+    {
+      title: 'Third Event',
+      start: new Date(2016, 10, 29, 8, 0),
+      end: new Date(2016, 10, 29, 21, 0),
+    },
+    {
+      title: 'Fourth Event',
+      start: new Date(2016, 10, 29, 9, 30),
+      end: new Date(2016, 10, 29, 19, 30),
+    },
+    {
+      title: 'Fifth Event',
+      start: new Date(2016, 10, 29, 11, 0),
+      end: new Date(2016, 10, 29, 18, 0),
+    },
+    {
+      title: 'Sixth Event',
+      start: new Date(2016, 11, 1, 9, 0),
+      end: new Date(2016, 11, 1, 14, 0),
+    },
+    {
+      title: 'Seventh Event',
+      start: new Date(2016, 11, 1, 11, 0),
+      end: new Date(2016, 11, 1, 16, 0),
+    },
+    {
+      title: 'Eighth Event',
+      start: new Date(2016, 11, 1, 13, 0),
+      end: new Date(2016, 11, 1, 18, 0),
+    },
+  ],
+}

--- a/test/utils/DayEventLayout.test.js
+++ b/test/utils/DayEventLayout.test.js
@@ -27,26 +27,7 @@ describe('getStyledEvents', () => {
   const accessors = { start: (e) => e.start, end: (e) => e.end }
 
   describe('with overlap dayLayoutAlgorithm', () => {
-    const dayLayoutAlgorithm = 'overlap'
-
-    function compare(title, events, expectedResults) {
-      it(title, () => {
-        const styledEvents = getStyledEvents({
-          events,
-          accessors,
-          slotMetrics,
-          minimumStartDifference: 10,
-          dayLayoutAlgorithm,
-        })
-        const results = styledEvents.map((result) => ({
-          width: Math.floor(result.style.width),
-          xOffset: Math.floor(result.style.xOffset),
-        }))
-        expect(results).toEqual(expectedResults)
-      })
-    }
-
-    const toCheck = [
+    it.each([
       [
         'single event',
         [{ start: d(11), end: d(12) }],
@@ -124,8 +105,24 @@ describe('getStyledEvents', () => {
           { width: 33, xOffset: 66 },
         ],
       ],
-    ]
-    toCheck.forEach((args) => compare(...args))
+    ])('%s', (_, events, expectedStyles) => {
+      const dayLayoutAlgorithm = 'overlap'
+
+      const styledEvents = getStyledEvents({
+        events,
+        accessors,
+        slotMetrics,
+        minimumStartDifference: 10,
+        dayLayoutAlgorithm,
+      })
+
+      const results = styledEvents.map((result) => ({
+        width: Math.floor(result.style.width),
+        xOffset: Math.floor(result.style.xOffset),
+      }))
+
+      expect(results).toEqual(expectedStyles)
+    })
   })
 
   describe('with no-overlap dayLayoutAlgorithm', () => {

--- a/test/utils/DayEventLayout.test.js
+++ b/test/utils/DayEventLayout.test.js
@@ -25,9 +25,10 @@ describe('getStyledEvents', () => {
     localizer,
   })
   const accessors = { start: (e) => e.start, end: (e) => e.end }
-  const dayLayoutAlgorithm = 'overlap'
 
-  describe('matrix', () => {
+  describe('with overlap dayLayoutAlgorithm', () => {
+    const dayLayoutAlgorithm = 'overlap'
+
     function compare(title, events, expectedResults) {
       it(title, () => {
         const styledEvents = getStyledEvents({
@@ -125,5 +126,113 @@ describe('getStyledEvents', () => {
       ],
     ]
     toCheck.forEach((args) => compare(...args))
+  })
+
+  describe('with no-overlap dayLayoutAlgorithm', () => {
+    it.each([
+      [
+        'single event',
+        [{ start: d(11), end: d(12) }],
+        [{ width: 'calc(100% - 0px)', xOffset: 'calc(0% + 0px)' }],
+      ],
+      [
+        'two consecutive events',
+        [
+          { start: d(11), end: d(11, 10) },
+          { start: d(11, 10), end: d(11, 20) },
+        ],
+        [
+          { width: 'calc(100% - 0px)', xOffset: 'calc(0% + 0px)' },
+          { width: 'calc(100% - 0px)', xOffset: 'calc(0% + 0px)' },
+        ],
+      ],
+      [
+        'two consecutive events too close together',
+        [
+          { start: d(11), end: d(11, 5) },
+          { start: d(11, 5), end: d(11, 10) },
+        ],
+        [
+          { width: 'calc(100% - 0px)', xOffset: 'calc(0% + 0px)' },
+          { width: 'calc(100% - 0px)', xOffset: 'calc(0% + 0px)' },
+        ],
+      ],
+      [
+        'two overlapping events',
+        [
+          { start: d(11), end: d(12) },
+          { start: d(11), end: d(12) },
+        ],
+        [
+          { width: 'calc(50% - 0px)', xOffset: 'calc(0% + 0px)' },
+          { width: 'calc(50% - 3px)', xOffset: 'calc(50% + 3px)' },
+        ],
+      ],
+      [
+        'three overlapping events',
+        [
+          { start: d(11), end: d(12) },
+          { start: d(11), end: d(12) },
+          { start: d(11), end: d(12) },
+        ],
+        [
+          {
+            width: 'calc(33.333333333333336% - 0px)',
+            xOffset: 'calc(0% + 0px)',
+          },
+          {
+            width: 'calc(33.333333333333336% - 3px)',
+            xOffset: 'calc(33.333333333333336% + 3px)',
+          },
+          {
+            width: 'calc(33.33333333333333% - 3px)',
+            xOffset: 'calc(66.66666666666667% + 3px)',
+          },
+        ],
+      ],
+      [
+        'one big event overlapping with two consecutive events',
+        [
+          { start: d(11), end: d(12) },
+          { start: d(11), end: d(11, 30) },
+          { start: d(11, 30), end: d(12) },
+        ],
+        [
+          { width: 'calc(50% - 0px)', xOffset: 'calc(0% + 0px)' },
+          { width: 'calc(50% - 3px)', xOffset: 'calc(50% + 3px)' },
+          { width: 'calc(50% - 3px)', xOffset: 'calc(50% + 3px)' },
+        ],
+      ],
+      [
+        'one big event overlapping with two consecutive events starting too close together',
+        [
+          { start: d(11), end: d(12) },
+          { start: d(11), end: d(11, 5) },
+          { start: d(11, 5), end: d(11, 10) },
+        ],
+        [
+          { width: 'calc(50% - 0px)', xOffset: 'calc(0% + 0px)' },
+          { width: 'calc(50% - 3px)', xOffset: 'calc(50% + 3px)' },
+          { width: 'calc(50% - 3px)', xOffset: 'calc(50% + 3px)' },
+        ],
+      ],
+    ])('%s', (_, events, expectedStyles) => {
+      const dayLayoutAlgorithm = 'no-overlap'
+
+      const styledEvents = getStyledEvents({
+        events,
+        accessors,
+        slotMetrics,
+        minimumStartDifference: 10,
+        dayLayoutAlgorithm,
+      })
+
+      const results = styledEvents.map((result) => ({
+        width: result.style.width,
+        xOffset: result.style.xOffset,
+      }))
+
+      expect(results).toEqual(expectedStyles)
+    })
   })
 })


### PR DESCRIPTION
This PR addresses two issues with how background events are rendered using both the `overlap` and `no-overlap` layout algorithms. I opted for the change I made due to its simplicity and the unlikelihood that it would have any adverse effects elsewhere in the calendar. It appears to me that the implementation of the `no-overlap` layout algorithm very deliberately returns different types for the `width` and `xOffset` style values than does the `overlap` algorithm; given this it seemed most reasonable to correct how those values are handled when rendering events in `TimeGridEvent`. 

I added two stories under "Additional Examples > Layout" to demonstrate the `overlap`/`no-overlap` behavior since that seemed like the most appropriate location for them.