### PR TITLE
fix: day events sort fixed

### DIFF
--- a/src/utils/layout-algorithms/no-overlap.js
+++ b/src/utils/layout-algorithms/no-overlap.js
@@ -29,7 +29,9 @@ export default function ({
     a = a.style
     b = b.style
     if (a.top !== b.top) return a.top > b.top ? 1 : -1
-    else return a.top + a.height < b.top + b.height ? 1 : -1
+    else if (a.height !== b.height)
+      return a.top + a.height < b.top + b.height ? 1 : -1
+    else return 0
   })
 
   for (let i = 0; i < styledEvents.length; ++i) {


### PR DESCRIPTION
![image](https://github.com/jquense/react-big-calendar/assets/21307445/c9e894fd-8671-4612-a4c9-f13a9e6d0e3d)
![image](https://github.com/jquense/react-big-calendar/assets/21307445/5e0f2785-3625-48a9-9a64-1478cac306cb)

There are two events, A and B, with the same start and end times. In the month view, event A is displayed before event B. However, in the week and day views, event B is displayed before event A, causing inconsistent display results. After reviewing the code logic for handling event order in the day view, I have fixed this issue to ensure consistent display results across all views.