### PR TITLE
fixes #2424 - fix js error TypeError: Cannot read properties of undef…

### DIFF
--- a/src/Month.js
+++ b/src/Month.js
@@ -336,6 +336,8 @@ class MonthView extends React.Component {
   }
 
   selectDates(slotInfo) {
+    if (!this._pendingSelection?.length) return;
+    
     let slots = this._pendingSelection.slice()
 
     this._pendingSelection = []


### PR DESCRIPTION
…ined (reading 'getDate')

see issue 2424 

you can repro the issue by clicking around a selectable month view of the calendar a lot and it helps to press keys at the same time (as is mentioned in the issue)

i think whats happening is that `handleSelectSlot` sets the `_pendingSelection` but then calls `selectDates` via setTimeout, and before `selectDates` executes something else calls `clearSelection` which empties out the `_pendingSelection` array. I've tested this fix and it seems to work - exiting early results in the slot not appearing selected and the onSelectSlot callback not being called