### PR TITLE
chore(deps): bump @babel/runtime from 7.20.7 to 7.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "zx": "^7.1.1"
   },
   "dependencies": {
-    "@babel/runtime": "^7.20.7",
+    "@babel/runtime": "^7.24.0",
     "clsx": "^1.2.1",
     "date-arithmetic": "^4.1.0",
     "dayjs": "^1.11.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1224,10 +1224,17 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.8", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.8", "@babel/runtime@^7.20.7", "@babel/runtime@^7.5.0", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.8", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.8", "@babel/runtime@^7.5.0", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.9.tgz#47791a15e4603bb5f905bc0753801cf21d6345f7"
   integrity sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
+"@babel/runtime@^7.24.0":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.0.tgz#584c450063ffda59697021430cb47101b085951e"
+  integrity sha512-Chk32uHMg6TnQdvw2e9IlqPpFX/6NLuK0Ys2PqLb7/gL5uFn9mXvK715FGLlOLQrcO4qIkNHkvPGktzzXexsFw==
   dependencies:
     regenerator-runtime "^0.14.0"
 


### PR DESCRIPTION
We recently updated react-big-calendar to the latest version and were getting the following error when packaging with ESBuild:

```
Could not resolve "@babel/runtime/helpers/esm/callSuper"
   node_modules/react-big-calendar/dist/react-big-calendar.esm.js:6:23:
     import _callSuper from '@babel/runtime/helpers/esm/callSuper';

 The path "./helpers/esm/callSuper" is not exported by package "@babel/runtime":

   node_modules/react-big-calendar/node_modules/@babel/runtime/package.json:19:13:
       "exports": {
```

I found this was the specific update that caused the error to appear for us:  [1.10.0 -> 1.10.1](https://github.com/jquense/react-big-calendar/compare/v1.10.0...v1.10.1) 
It seems to update some @babel packages which makes sense. Something in that update broke the `callSuper` export from the looks of things. However, bumping to the latest version of @babel/runtime seems to fix things.

Looking at the changes to `yarn.lock` in this PR the dependency for @babel/runtime seems to appear twice now which I don't fully understand. 
