### PR TITLE
fix: issue 2536

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.11.1](https://github.com/jquense/react-big-calendar/compare/v1.11.0...v1.11.1) (2024-03-04)
+
+
+### Bug Fixes
+
+* replace deprecated onKeyPress by onKeyDown ([21f51f2](https://github.com/jquense/react-big-calendar/commit/21f51f2bc4e218542fb09bf0e7d22be99ed50028))
+
 # [1.11.0](https://github.com/jquense/react-big-calendar/compare/v1.10.3...v1.11.0) (2024-02-26)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-big-calendar",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Calendar! with events",
   "author": {
     "name": "Jason Quense",

--- a/src/utils/TimeSlots.js
+++ b/src/utils/TimeSlots.js
@@ -68,12 +68,19 @@ export function getSlotMetrics({
     },
 
     nextSlot(slot) {
-      let next = slots[Math.min(slots.indexOf(slot) + 1, slots.length - 1)]
+      // We cannot guarantee that the slot object must be in slots,
+      // because after each update, a new slots array will be created.
+      let next =
+        slots[
+          Math.min(
+            slots.findIndex((s) => localizer.eq(s, slot)) + 1,
+            slots.length - 1
+          )
+        ]
       // in the case of the last slot we won't a long enough range so manually get it
-      if (next === slot) next = localizer.add(slot, step, 'minutes')
+      if (localizer.eq(next, slot)) next = localizer.add(slot, step, 'minutes')
       return next
     },
-
     closestSlotToPosition(percent) {
       const slot = Math.min(
         slots.length - 1,

--- a/src/utils/TimeSlots.js
+++ b/src/utils/TimeSlots.js
@@ -73,7 +73,7 @@ export function getSlotMetrics({
       let next =
         slots[
           Math.min(
-            slots.findIndex((s) => localizer.eq(s, slot)) + 1,
+            slots.findIndex((s) => s === slot || localizer.eq(s, slot)) + 1,
             slots.length - 1
           )
         ]


### PR DESCRIPTION
This is a commit to fix[ issue 2536](https://github.com/jquense/react-big-calendar/issues/2536) and [2529](https://github.com/jquense/react-big-calendar/issues/2529).

When I was fixing [2529](https://github.com/jquense/react-big-calendar/issues/2529), I declared `slotMetrics` as a global variable, which caused all `DayColumn` instances to use the same instance of `slotMetrics`. This is also the reason why bug [ issue 2536](https://github.com/jquense/react-big-calendar/issues/2536) appears.

In this commit, I only modified the update timing of slotMetrics.Now both issues are resolved!


https://github.com/jquense/react-big-calendar/assets/63057542/756fc1b7-972e-4ef3-bb72-516e068218ac

