### PR TITLE
fix(docs): correct link for 'props' in 'Understanding Dates' guide

### DIFF
--- a/stories/guides/Dates.stories.mdx
+++ b/stories/guides/Dates.stories.mdx
@@ -5,7 +5,7 @@ import LinkTo from '@storybook/addon-links/react'
 
 # Understanding Dates
 
-Big Calendar is all about dates and times. Probably one of the easiest things that beginners miss, when first implementing Big Calendar, is that we **require** true JS [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) objects in our <LinkTo kind="props">props</LinkTo> and `event` definitions.
+Big Calendar is all about dates and times. Probably one of the easiest things that beginners miss, when first implementing Big Calendar, is that we **require** true JS [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) objects in our <LinkTo kind="props" story="Full Prop List">props</LinkTo> and `event` definitions.
 
 It is **up to the developer** to handle translating date/time values **to and from JS `Date` format**.
 


### PR DESCRIPTION
This commit addresses issue #2561  by resolving a broken link for the 'props' section within the 'Understanding Dates' guide. The fix ensures that users can now navigate seamlessly to the relevant documentation without encountering any errors.
