### PR TITLE
fix: issue #2534

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ const MyCalendar = (props) => (
 Note that the dayjsLocalizer extends Day.js with the following plugins:
 
 - [IsBetween](https://day.js.org/docs/en/plugin/is-between)
+- [IsLeapYear](https://day.js.org/docs/en/plugin/is-leap-year)
 - [IsSameOrAfter](https://day.js.org/docs/en/plugin/is-same-or-after)
 - [IsSameOrBefore](https://day.js.org/docs/en/plugin/is-same-or-before)
 - [LocaleData](https://day.js.org/docs/en/plugin/locale-data)

--- a/src/Month.js
+++ b/src/Month.js
@@ -160,7 +160,7 @@ class MonthView extends React.Component {
 
   readerDateHeading = ({ date, className, ...props }) => {
     let { date: currentDate, getDrilldownView, localizer } = this.props
-    let isOffRange = localizer.neq(date, currentDate, 'month')
+    let isOffRange = localizer.neq(currentDate, date, 'month')
     let isCurrent = localizer.isSameDate(date, currentDate)
     let drilldownView = getDrilldownView(date)
     let label = localizer.format(date, 'dateFormat')

--- a/src/localizers/dayjs.js
+++ b/src/localizers/dayjs.js
@@ -196,9 +196,6 @@ export default function (dayjsLib) {
   }
 
   function add(date, adder, unit) {
-    // console.log(`${dayjs(date).format('MM/DD/YYYY')} + ${adder} ${unit}`)
-    // console.log(dayjs(date).add(adder, unit).format('MM/DD/YYYY'))
-    // console.log(dayjs(date).add(adder, unit).toDate())
     const datePart = fixUnit(unit)
     return dayjs(date).add(adder, datePart).toDate()
   }

--- a/src/localizers/dayjs.js
+++ b/src/localizers/dayjs.js
@@ -10,6 +10,7 @@ import localeData from 'dayjs/plugin/localeData'
 import localizedFormat from 'dayjs/plugin/localizedFormat'
 import minMax from 'dayjs/plugin/minMax'
 import utc from 'dayjs/plugin/utc'
+import isLeapYear from 'dayjs/plugin/isLeapYear'
 
 const weekRangeFormat = ({ start, end }, culture, local) =>
   local.format(start, 'MMMM DD', culture) +
@@ -70,6 +71,7 @@ export default function (dayjsLib) {
   dayjsLib.extend(localizedFormat)
   dayjsLib.extend(minMax)
   dayjsLib.extend(utc)
+  dayjsLib.extend(isLeapYear)
 
   const locale = (dj, c) => (c ? dj.locale(c) : dj)
 
@@ -194,6 +196,9 @@ export default function (dayjsLib) {
   }
 
   function add(date, adder, unit) {
+    // console.log(`${dayjs(date).format('MM/DD/YYYY')} + ${adder} ${unit}`)
+    // console.log(dayjs(date).add(adder, unit).format('MM/DD/YYYY'))
+    // console.log(dayjs(date).add(adder, unit).toDate())
     const datePart = fixUnit(unit)
     return dayjs(date).add(adder, datePart).toDate()
   }
@@ -238,7 +243,15 @@ export default function (dayjsLib) {
   }
 
   function firstVisibleDay(date) {
-    return dayjs(date).startOf('month').startOf('week').toDate()
+    const firstDayOfMonth = dayjs(date).startOf('month')
+    let firstDayOfWeek = dayjs(firstDayOfMonth).startOf('week')
+    // special handling for leapyears until Dayjs patches it
+    if (dayjs(firstDayOfMonth).isLeapYear()) {
+      const day = firstDayOfMonth.toDate().getDay(),
+        diff = firstDayOfMonth.toDate().getDate() - day + (day == 0 ? -6 : 1)
+      firstDayOfWeek.date(diff)
+    }
+    return firstDayOfWeek.toDate()
   }
 
   function lastVisibleDay(date) {


### PR DESCRIPTION
this commit fixes the issues mentioned in #2534 

In cases of leap years, the month of March would often display unexpected off-range days / missing days entirely.
This includes special handling for leapyears, and does manual math to get the start of the week rather than Dayjs' `startOf`.
