### PR TITLE
fix: #2565 doubleClick

### DIFF
--- a/src/Selection.js
+++ b/src/Selection.js
@@ -352,7 +352,6 @@ class Selection {
     this._selectRect = null
     this._initialEvent = null
     this._initialEventData = null
-    this._lastClickData = null
     if (!e) return
 
     let inRoot = !this.container || contains(this.container(), e.target)


### PR DESCRIPTION
When `_handleTerminatingEvent` is executed, `_lastClickData` will no longer be cleared to trigger the `doubleClick` event.
This PR was created to fix [#2565](https://github.com/jquense/react-big-calendar/issues/2565).