### PR TITLE
fix: fixing Drag and Drop Examples link

### DIFF
--- a/stories/demos/dragAndDrop.stories.mdx
+++ b/stories/demos/dragAndDrop.stories.mdx
@@ -5,4 +5,4 @@ import LinkTo from '@storybook/addon-links/react'
 
 # Drag and Drop
 
-The <LinkTo kind="addons-drag-and-drop">Drag and Drop Examples</LinkTo> have been moved into the <LinkTo kind="addons-introduction">AddOns</LinkTo> section of the documentation
+The <LinkTo kind="addons-drag-and-drop-introduction">Drag and Drop Examples</LinkTo> have been moved into the <LinkTo kind="addons-introduction">AddOns</LinkTo> section of the documentation


### PR DESCRIPTION
This pull request closes #2584


After consulting the different examples provided as part of react Big Calendar, it came to my attention that the Drag and Drop Examples link is not functioning properly. When clicking on a link, it throws the an error message. 

I have changed the code to have the appropriate prop, which will link back to the correct section under AddOns section.

This PR removes the error and correctly links the Drag and Drop to its corresponding section in the App.