### PR TITLE
fix: remove onSelectSlot event handler as its only creating empty ev…

### DIFF
--- a/stories/demos/exampleCode/dndOutsideSource.js
+++ b/stories/demos/exampleCode/dndOutsideSource.js
@@ -180,7 +180,6 @@ export default function DnDOutsideResource({ localizer }) {
           onDragOver={customOnDragOver}
           onEventDrop={moveEvent}
           onEventResize={resizeEvent}
-          onSelectSlot={newEvent}
           resizable
           selectable
         />


### PR DESCRIPTION
The issue was that clicking on a date on the calendar was creating empty events that would fill up the calendar.
This was happening because the `onSelectSlot` prop was linked to the `newEvent` function, which was creating empty events.

Removed `onSelectSlot`. 
Functionality now more in align with the other storybook section, Basic Drag n Drop, where clicking on the dates does not do anything.

Closes #2587