### PR TITLE
Expose View Utilites

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,16 @@
 import EventWrapper from './EventWrapper'
 import BackgroundWrapper from './BackgroundWrapper'
+import viewUtilities from './viewUtilities'
+import TimeGrid from './TimeGrid'
+import TimeGridEvent from './TimeGridEvent'
+import TimeGridHeader from './TimeGridHeader'
+import TimeGutter from './TimeGutter'
 
 export const components = {
+  TimeGrid: TimeGrid,
+  TimeGridHeader: TimeGridHeader,
+  TimeGridEvent: TimeGridEvent,
+  TimeGutter: TimeGutter,
   eventWrapper: EventWrapper,
   timeSlotWrapper: BackgroundWrapper,
   dateCellWrapper: BackgroundWrapper,


### PR DESCRIPTION
## Utilities Export
Utilities like TimeGrid should be public. Most custom views are similar/expand the ones react-big-calendar already has. In order to make development easier for users of our library, More utilities should be public. 

This single commit exposes TimeGrid, TimeGridHeader, TimeGridEvent, TimeGutter, EventWrapper.
More could be exposed but these are the ones *I* see the most requested.

In the future I would love big-react-calendar to have a utility import which provides basic components for addons and extensions.


I humbly thank you for your time and consideration - Andrew