### PR TITLE
fix(dnd): add correct dragOverFromOutside behavior in week view

### DIFF
--- a/src/addons/dragAndDrop/EventContainerWrapper.js
+++ b/src/addons/dragAndDrop/EventContainerWrapper.js
@@ -126,6 +126,18 @@ class EventContainerWrapper extends React.Component {
     })
   }
 
+  handleDragOverFromOutside = (point, bounds) => {
+    const { slotMetrics } = this.props
+
+    const start = slotMetrics.closestSlotFromPoint(
+      { y: point.y, x: point.x },
+      bounds
+    )
+    const end = slotMetrics.nextSlot(start)
+    const event = this.context.draggable.dragFromOutsideItem()
+    this.update(event, slotMetrics.getRange(start, end, false, true))
+  }
+
   updateParentScroll = (parent, node) => {
     setTimeout(() => {
       const draggedEl = qsa(node, '.rbc-addons-dnd-drag-preview')[0]
@@ -200,10 +212,11 @@ class EventContainerWrapper extends React.Component {
       this.handleDropFromOutside(point, bounds)
     })
 
-    selector.on('dragOver', (point) => {
+    selector.on('dragOverFromOutside', (point) => {
       if (!this.context.draggable.dragFromOutsideItem) return
       const bounds = getBoundsForNode(node)
-      this.handleDropFromOutside(point, bounds)
+      if (!pointInColumn(bounds, point)) return this.reset()
+      this.handleDragOverFromOutside(point, bounds)
     })
 
     selector.on('selectStart', () => {


### PR DESCRIPTION
Hey,

This is an attempt to fix https://github.com/jquense/react-big-calendar/issues/2383.

The 2 issues I noticed were: 
- The selectors were listening to the wrong event ( `dragOver` instead of `dragOverFromOutside` )
- The old dragOver code called the `handleDrop` which is not exactly true ! 

It's not breaking, as the old "dragOver" event was never emitted, so the code was never called (from my understanding)! 

I'd love to have your feedback, and I'd be happy to add tests or better documentation if deemed necessary ! 

This is how it looks on the storybooks 

https://github.com/jquense/react-big-calendar/assets/63306573/d8fbb4a2-80d9-4424-b344-950a6ec4c163




