### PR TITLE
Identifies backgroundEvents as an event, preventing onSelectSlot triggers when backgroundEvent is clicked

### DIFF
--- a/src/Selection.js
+++ b/src/Selection.js
@@ -12,7 +12,10 @@ function isOverContainer(container, x, y) {
 
 export function getEventNodeFromPoint(node, { clientX, clientY }) {
   let target = document.elementFromPoint(clientX, clientY)
-  return closest(target, '.rbc-event', node)
+  return (
+    closest(target, '.rbc-event', node) ||
+    closest(target, '.rbc-background-event', node)
+  )
 }
 
 export function getShowMoreNodeFromPoint(node, { clientX, clientY }) {


### PR DESCRIPTION
Closes #2618 

