### PR TITLE
fix: warning defaultProps in Agenda

### DIFF
--- a/src/Agenda.js
+++ b/src/Agenda.js
@@ -9,13 +9,14 @@ import { navigate } from './utils/constants'
 import { inRange } from './utils/eventLevels'
 import { isSelected } from './utils/selection'
 
+const DEFAULT_LENGTH = 30;
 function Agenda({
   accessors,
   components,
   date,
   events,
   getters,
-  length,
+  length = DEFAULT_LENGTH,
   localizer,
   onDoubleClickEvent,
   onSelectEvent,
@@ -217,11 +218,7 @@ Agenda.propTypes = {
   selected: PropTypes.object,
 }
 
-Agenda.defaultProps = {
-  length: 30,
-}
-
-Agenda.range = (start, { length = Agenda.defaultProps.length, localizer }) => {
+Agenda.range = (start, { length = DEFAULT_LENGTH, localizer }) => {
   let end = localizer.add(start, length, 'day')
   return { start, end }
 }
@@ -229,7 +226,7 @@ Agenda.range = (start, { length = Agenda.defaultProps.length, localizer }) => {
 Agenda.navigate = (
   date,
   action,
-  { length = Agenda.defaultProps.length, localizer }
+  { length = DEFAULT_LENGTH, localizer }
 ) => {
   switch (action) {
     case navigate.PREVIOUS:
@@ -243,7 +240,7 @@ Agenda.navigate = (
   }
 }
 
-Agenda.title = (start, { length = Agenda.defaultProps.length, localizer }) => {
+Agenda.title = (start, { length = DEFAULT_LENGTH, localizer }) => {
   let end = localizer.add(start, length, 'day')
   return localizer.format({ start, end }, 'agendaHeaderFormat')
 }


### PR DESCRIPTION
Fix warning on agenda view

![Screenshot 2024-07-12 at 23 36 43](https://github.com/user-attachments/assets/96251874-9670-40eb-8c6a-26160d7b8124)

Version:
- "react": "18.2.0"
- "react-big-calendar": "1.13.0"
- "next": "14.2.4"