### PR TITLE
Make the inBetween function exlcusive for the ending time

### DIFF
--- a/src/localizers/moment.js
+++ b/src/localizers/moment.js
@@ -144,7 +144,7 @@ export default function (moment) {
     const mDay = moment(day)
     const mMin = moment(min)
     const mMax = moment(max)
-    return mDay.isBetween(mMin, mMax, datePart, '[]')
+    return mDay.isBetween(mMin, mMax, datePart, '[)')
   }
 
   function min(dateA, dateB) {


### PR DESCRIPTION
Fixes #2617 

By passing in the exclusive argument, this will not mark events that end at mightnight from leaking into the next day in the week view

<img width="1159" alt="Screenshot 2024-07-12 at 10 00 42 PM" src="https://github.com/user-attachments/assets/282fcb76-a28e-4a41-86a5-1618b5aba743">
 
