### PR TITLE
Fix: Sass warning on latest version

### DIFF
--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -101,13 +101,13 @@
     height: 100%;
     overflow-y: scroll;
 
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
+
     /* Hide scrollbar for Chrome, Safari and Opera */
     &::-webkit-scrollbar {
       display: none;
     }
-
-    -ms-overflow-style: none; /* IE and Edge */
-    scrollbar-width: none; /* Firefox */
   }
 }
 


### PR DESCRIPTION
This pull request addresses an issue with the calendar styling. The SCSS variables were not being applied correctly due to changes in Sass behavior. This PR updates the SCSS files to ensure the variables are applied correctly and resolves styling issues.

Warning in Console on Sass latest version:
`Sass's behavior for declarations that appear after nested rules will be changing to match the behavior specified by CSS in an upcoming version. To keep the existing behavior, move the declaration above the nested rule. To opt into the new behavior, wrap the declaration in & {}`

Changes Made:
Moved variable declarations to ensure that variables are declared before their rules