### PR TITLE
refactor(a11y): aria role cell is not allowed for button element

### DIFF
--- a/src/DateHeader.js
+++ b/src/DateHeader.js
@@ -7,12 +7,7 @@ const DateHeader = ({ label, drilldownView, onDrillDown }) => {
   }
 
   return (
-    <button
-      type="button"
-      className="rbc-button-link"
-      onClick={onDrillDown}
-      role="cell"
-    >
+    <button type="button" className="rbc-button-link" onClick={onDrillDown}>
       {label}
     </button>
   )


### PR DESCRIPTION
**Summary:**

According to [a11y](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/cell_role#description) - ARIA role cell is not allowed for a button element in the current context.

**Solution:**

Remove attribute **role="cell"** from a button element for the DateHeader component.
