### PR TITLE
Fix error when clicking on header on default view

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -1086,12 +1086,8 @@ class Calendar extends React.Component {
   handleRangeChange = (date, viewComponent, view) => {
     let { onRangeChange, localizer } = this.props
 
-    if (!viewComponent) {
-      return;
-    }
-
     if (onRangeChange) {
-      if (viewComponent.range) {
+      if (viewComponent?.range) {
         onRangeChange(viewComponent.range(date, { localizer }), view)
       } else {
         if (process.env.NODE_ENV !== 'production') {

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -1086,6 +1086,10 @@ class Calendar extends React.Component {
   handleRangeChange = (date, viewComponent, view) => {
     let { onRangeChange, localizer } = this.props
 
+    if (!viewComponent) {
+      return;
+    }
+
     if (onRangeChange) {
       if (viewComponent.range) {
         onRangeChange(viewComponent.range(date, { localizer }), view)


### PR DESCRIPTION
Hello,

I noticed that when clicking the text in the header on default view, the `handleRangeChange` would be invoked with `viewComponent` === `undefined`.

I have patched the package to avoid the error logs, and am submitting this fix. Feel free to modify if needs be!