### PR TITLE
fix(dnd): added check for null dragFromOutsideItem, updated example

### DIFF
--- a/src/addons/dragAndDrop/EventContainerWrapper.js
+++ b/src/addons/dragAndDrop/EventContainerWrapper.js
@@ -126,6 +126,18 @@ class EventContainerWrapper extends React.Component {
     })
   }
 
+  handleDragOverFromOutside = (point, bounds) => {
+    const { slotMetrics } = this.props
+
+    const start = slotMetrics.closestSlotFromPoint(
+      { y: point.y, x: point.x },
+      bounds
+    )
+    const end = slotMetrics.nextSlot(start)
+    const event = this.context.draggable.dragFromOutsideItem()
+    this.update(event, slotMetrics.getRange(start, end, false, true))
+  }
+
   updateParentScroll = (parent, node) => {
     setTimeout(() => {
       const draggedEl = qsa(node, '.rbc-addons-dnd-drag-preview')[0]
@@ -200,10 +212,12 @@ class EventContainerWrapper extends React.Component {
       this.handleDropFromOutside(point, bounds)
     })
 
-    selector.on('dragOver', (point) => {
-      if (!this.context.draggable.dragFromOutsideItem) return
+    selector.on('dragOverFromOutside', (point) => {
+      const item = this.context.draggable.dragFromOutsideItem ? this.context.draggable.dragFromOutsideItem() : null
+      if (!item) return
       const bounds = getBoundsForNode(node)
-      this.handleDropFromOutside(point, bounds)
+      if (!pointInColumn(bounds, point)) return this.reset()
+      this.handleDragOverFromOutside(point, bounds)
     })
 
     selector.on('selectStart', () => {

--- a/src/addons/dragAndDrop/WeekWrapper.js
+++ b/src/addons/dragAndDrop/WeekWrapper.js
@@ -91,8 +91,9 @@ class WeekWrapper extends React.Component {
   }
 
   handleDragOverFromOutside = (point, node) => {
-    if (!this.context.draggable.dragFromOutsideItem) return
-    this.handleMove(point, node, this.context.draggable.dragFromOutsideItem())
+    const item = this.context.draggable.dragFromOutsideItem ? this.context.draggable.dragFromOutsideItem() : null
+    if (!item) return
+    this.handleMove(point, node, item)
   }
 
   handleResize(point, bounds) {

--- a/stories/demos/exampleCode/dndOutsideSource.js
+++ b/stories/demos/exampleCode/dndOutsideSource.js
@@ -35,9 +35,9 @@ export default function DnDOutsideResource({ localizer }) {
   //,
   const handleDragStart = useCallback((event) => setDraggedEvent(event), [])
 
-  const dragFromOutsideItem = useCallback(() => draggedEvent, [draggedEvent])
+  const dragFromOutsideItem = useCallback(() => draggedEvent === 'undroppable' ? null : draggedEvent, [draggedEvent])
 
-  const customOnDragOver = useCallback(
+  const customOnDragOverFromOutside = useCallback(
     (dragEvent) => {
       // check for undroppable is specific to this example
       // and not part of API. This just demonstrates that
@@ -177,7 +177,7 @@ export default function DnDOutsideResource({ localizer }) {
           events={myEvents}
           localizer={localizer}
           onDropFromOutside={onDropFromOutside}
-          onDragOver={customOnDragOver}
+          onDragOverFromOutside={customOnDragOverFromOutside}
           onEventDrop={moveEvent}
           onEventResize={resizeEvent}
           onSelectSlot={newEvent}


### PR DESCRIPTION
Based on the work of @achrafl0 in https://github.com/jquense/react-big-calendar/pull/2616 and an attempt to fix https://github.com/jquense/react-big-calendar/issues/2383.

While testing I noticed that the current example is not quite correct.

The event is always triggered inside the calendar, and the only thing that prevents the event from being displayed in the month view is that it lacks a title (so only one line is displayed). This does not work in the week view because the time is known and so the event box is displayed. (You can see that if you drag over the day header column, a line is also displayed.

So I have made some changes in the example to avoid sending a `dragFromOutsideItem` at all, and added checks in the listeners accordingly.

Looking forward to your feedback.