### PR TITLE
Implement Conditional Resource Grouping

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -1,28 +1,28 @@
+import clsx from 'clsx'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { uncontrollable } from 'uncontrollable'
-import clsx from 'clsx'
 import {
   accessor,
+  views as componentViews,
   dateFormat,
   dateRangeFormat,
   DayLayoutAlgorithmPropType,
-  views as componentViews,
 } from './utils/propTypes'
 
-import { notify } from './utils/helpers'
-import { navigate, views } from './utils/constants'
 import { mergeWithDefaults } from './localizer'
+import NoopWrapper from './NoopWrapper'
+import Toolbar from './Toolbar'
+import { navigate, views } from './utils/constants'
+import { notify } from './utils/helpers'
 import message from './utils/messages'
 import moveDate from './utils/move'
 import VIEWS from './Views'
-import Toolbar from './Toolbar'
-import NoopWrapper from './NoopWrapper'
 
-import omit from 'lodash/omit'
 import defaults from 'lodash/defaults'
-import transform from 'lodash/transform'
 import mapValues from 'lodash/mapValues'
+import omit from 'lodash/omit'
+import transform from 'lodash/transform'
 import { wrapAccessor } from './utils/accessors'
 
 function viewNames(_views) {
@@ -633,6 +633,13 @@ class Calendar extends React.Component {
     enableAutoScroll: PropTypes.bool,
 
     /**
+     * Determines the layout of resource groups in the calendar.
+     * When `true`, resources will be grouped by date in the week view.
+     * When `false`, resources will be grouped by week.
+     */
+    resourceGroupingLayout: PropTypes.bool,
+
+    /**
      * Specify a specific culture code for the Calendar.
      *
      * **Note: it's generally better to handle this globally via your i18n library.**
@@ -1006,6 +1013,7 @@ class Calendar extends React.Component {
       toolbar,
       events,
       backgroundEvents,
+      resourceGroupingLayout,
       style,
       className,
       elementProps,
@@ -1069,6 +1077,7 @@ class Calendar extends React.Component {
           onSelectSlot={this.handleSelectSlot}
           onShowMore={onShowMore}
           doShowMoreDrillDown={doShowMoreDrillDown}
+          resourceGroupingLayout={resourceGroupingLayout}
         />
       </div>
     )

--- a/src/TimeGridHeaderResources.js
+++ b/src/TimeGridHeaderResources.js
@@ -82,7 +82,14 @@ class TimeGridHeaderResources extends React.Component {
           <div className="rbc-row">
             {resources.map(([id, resource], idx) => {
               return (
-                <div key={`resource_${id}_${idx}`} className="rbc-header">
+                <div
+                  key={`resource_${id}_${idx}`}
+                  className={clsx(
+                    'rbc-header',
+                    className,
+                    localizer.isSameDate(date, today) && 'rbc-today'
+                  )}
+                >
                   <ResourceHeaderComponent
                     index={idx}
                     label={accessors.resourceTitle(resource)}

--- a/src/TimeGridHeaderResources.js
+++ b/src/TimeGridHeaderResources.js
@@ -38,7 +38,7 @@ class TimeGridHeaderResources extends React.Component {
 
     const groupedEvents = resources.groupEvents(events)
 
-    return range.map((date, i) => {
+    return range.map((date, idx) => {
       let drilldownView = getDrilldownView(date)
       let label = localizer.format(date, 'dayFormat')
 
@@ -49,14 +49,13 @@ class TimeGridHeaderResources extends React.Component {
       )
 
       return (
-        <div className="rbc-time-header-content">
+        <div key={idx} className="rbc-time-header-content">
           <div
             className={`rbc-row rbc-time-header-cell${
               range.length <= 1 ? ' rbc-time-header-cell-single-day' : ''
             }`}
           >
             <div
-              key={i}
               style={style}
               className={clsx(
                 'rbc-header',
@@ -83,7 +82,7 @@ class TimeGridHeaderResources extends React.Component {
           <div className="rbc-row">
             {resources.map(([id, resource], idx) => {
               return (
-                <div key={`resource_${id}`} className="rbc-header">
+                <div key={`resource_${id}_${idx}`} className="rbc-header">
                   <ResourceHeaderComponent
                     index={idx}
                     label={accessors.resourceTitle(resource)}
@@ -95,7 +94,7 @@ class TimeGridHeaderResources extends React.Component {
           </div>
 
           <div className="rbc-row rbc-m-b-negative-3">
-            {resources.map(([id, resource]) => {
+            {resources.map(([id, resource], idx) => {
               // Filter the grouped events by the current date.
               const filteredEvents = (groupedEvents.get(id) || []).filter(
                 (event) =>
@@ -105,7 +104,7 @@ class TimeGridHeaderResources extends React.Component {
 
               return (
                 <DateContentRow
-                  key={`resource_${id}`}
+                  key={`resource_${id}_${idx}`}
                   isAllDay
                   rtl={rtl}
                   getNow={getNow}

--- a/src/TimeGridHeaderResources.js
+++ b/src/TimeGridHeaderResources.js
@@ -1,0 +1,206 @@
+import clsx from 'clsx'
+import scrollbarSize from 'dom-helpers/scrollbarSize'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import DateContentRow from './DateContentRow'
+import Header from './Header'
+import ResourceHeader from './ResourceHeader'
+import { notify } from './utils/helpers'
+
+class TimeGridHeaderResources extends React.Component {
+  handleHeaderClick = (date, view, e) => {
+    e.preventDefault()
+    notify(this.props.onDrillDown, [date, view])
+  }
+
+  renderHeaderCells(range) {
+    let {
+      localizer,
+      getDrilldownView,
+      getNow,
+      getters: { dayProp },
+      components: {
+        header: HeaderComponent = Header,
+        resourceHeader: ResourceHeaderComponent = ResourceHeader,
+      },
+      resources,
+      accessors,
+      events,
+      rtl,
+      selectable,
+      components,
+      getters,
+      resizable,
+    } = this.props
+
+    const today = getNow()
+
+    const groupedEvents = resources.groupEvents(events)
+
+    return range.map((date, i) => {
+      let drilldownView = getDrilldownView(date)
+      let label = localizer.format(date, 'dayFormat')
+
+      const { className, style } = dayProp(date)
+
+      let header = (
+        <HeaderComponent date={date} label={label} localizer={localizer} />
+      )
+
+      return (
+        <div className="rbc-time-header-content">
+          <div
+            className={`rbc-row rbc-time-header-cell${
+              range.length <= 1 ? ' rbc-time-header-cell-single-day' : ''
+            }`}
+          >
+            <div
+              key={i}
+              style={style}
+              className={clsx(
+                'rbc-header',
+                className,
+                localizer.isSameDate(date, today) && 'rbc-today'
+              )}
+            >
+              {drilldownView ? (
+                <button
+                  type="button"
+                  className="rbc-button-link"
+                  onClick={(e) =>
+                    this.handleHeaderClick(date, drilldownView, e)
+                  }
+                >
+                  {header}
+                </button>
+              ) : (
+                <span>{header}</span>
+              )}
+            </div>
+          </div>
+
+          <div className="rbc-row">
+            {resources.map(([id, resource], idx) => {
+              return (
+                <div key={`resource_${id}`} className="rbc-header">
+                  <ResourceHeaderComponent
+                    index={idx}
+                    label={accessors.resourceTitle(resource)}
+                    resource={resource}
+                  />
+                </div>
+              )
+            })}
+          </div>
+
+          <div className="rbc-row rbc-m-b-negative-3">
+            {resources.map(([id, resource]) => {
+              // Filter the grouped events by the current date.
+              const filteredEvents = (groupedEvents.get(id) || []).filter(
+                (event) =>
+                  localizer.isSameDate(event.start, date) ||
+                  localizer.isSameDate(event.end, date)
+              )
+
+              return (
+                <DateContentRow
+                  key={`resource_${id}`}
+                  isAllDay
+                  rtl={rtl}
+                  getNow={getNow}
+                  minRows={2}
+                  maxRows={this.props.allDayMaxRows + 1}
+                  range={[date]} // This ensures that only the single day is rendered
+                  events={filteredEvents} // Only show filtered events for this day.
+                  resourceId={resource && id}
+                  className="rbc-allday-cell"
+                  selectable={selectable}
+                  selected={this.props.selected}
+                  components={components}
+                  accessors={accessors}
+                  getters={getters}
+                  localizer={localizer}
+                  onSelect={this.props.onSelectEvent}
+                  onShowMore={this.props.onShowMore}
+                  onDoubleClick={this.props.onDoubleClickEvent}
+                  onKeyDown={this.props.onKeyPressEvent}
+                  onSelectSlot={this.props.onSelectSlot}
+                  longPressThreshold={this.props.longPressThreshold}
+                  resizable={resizable}
+                />
+              )
+            })}
+          </div>
+        </div>
+      )
+    })
+  }
+
+  render() {
+    let {
+      width,
+      rtl,
+      range,
+      scrollRef,
+      isOverflowing,
+      components: { timeGutterHeader: TimeGutterHeader },
+    } = this.props
+
+    let style = {}
+    if (isOverflowing) {
+      style[rtl ? 'marginLeft' : 'marginRight'] = `${scrollbarSize() - 1}px`
+    }
+
+    return (
+      <div
+        style={style}
+        ref={scrollRef}
+        className={clsx('rbc-time-header', isOverflowing && 'rbc-overflowing')}
+      >
+        <div
+          className="rbc-label rbc-time-header-gutter"
+          style={{ width, minWidth: width, maxWidth: width }}
+        >
+          {TimeGutterHeader && <TimeGutterHeader />}
+        </div>
+
+        {this.renderHeaderCells(range)}
+      </div>
+    )
+  }
+}
+
+TimeGridHeaderResources.propTypes = {
+  range: PropTypes.array.isRequired,
+  events: PropTypes.array.isRequired,
+  resources: PropTypes.object,
+  getNow: PropTypes.func.isRequired,
+  isOverflowing: PropTypes.bool,
+
+  rtl: PropTypes.bool,
+  resizable: PropTypes.bool,
+  width: PropTypes.number,
+
+  localizer: PropTypes.object.isRequired,
+  accessors: PropTypes.object.isRequired,
+  components: PropTypes.object.isRequired,
+  getters: PropTypes.object.isRequired,
+
+  selected: PropTypes.object,
+  selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),
+  longPressThreshold: PropTypes.number,
+
+  allDayMaxRows: PropTypes.number,
+
+  onSelectSlot: PropTypes.func,
+  onSelectEvent: PropTypes.func,
+  onDoubleClickEvent: PropTypes.func,
+  onKeyPressEvent: PropTypes.func,
+  onDrillDown: PropTypes.func,
+  onShowMore: PropTypes.func,
+  getDrilldownView: PropTypes.func.isRequired,
+  scrollRef: PropTypes.any,
+}
+
+export default TimeGridHeaderResources

--- a/src/sass/month.scss
+++ b/src/sass/month.scss
@@ -91,6 +91,7 @@
   flex-direction: row;
   flex: 1 0 0;
   overflow: hidden;
+  right: 1px;
 }
 
 .rbc-day-bg {

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -9,6 +9,10 @@
   align-items: stretch;
 }
 
+.rbc-m-b-negative-3 {
+  margin-bottom: -3px;
+}
+
 .rbc-calendar *,
 .rbc-calendar *:before,
 .rbc-calendar *:after {

--- a/stories/demos/exampleCode/resource.js
+++ b/stories/demos/exampleCode/resource.js
@@ -1,8 +1,8 @@
-import React, { Fragment, useMemo } from 'react'
-import PropTypes from 'prop-types'
-import { Calendar, Views, DateLocalizer } from 'react-big-calendar'
-import DemoLink from '../../DemoLink.component'
 import LinkTo from '@storybook/addon-links/react'
+import PropTypes from 'prop-types'
+import React, { Fragment, useMemo, useState } from 'react'
+import { Calendar, DateLocalizer, Views } from 'react-big-calendar'
+import DemoLink from '../../DemoLink.component'
 
 const events = [
   {
@@ -44,6 +44,8 @@ const resourceMap = [
 ]
 
 export default function Resource({ localizer }) {
+  const [groupResourcesOnWeek, setGroupResourcesOnWeek] = useState(false)
+
   const { defaultDate, views } = useMemo(
     () => ({
       defaultDate: new Date(2018, 0, 29),
@@ -56,10 +58,32 @@ export default function Resource({ localizer }) {
     <Fragment>
       <DemoLink fileName="resource" />
       <strong>
-        The calendar below uses the <LinkTo kind="props" story="resource-id-accessor">resourceIdAccessor</LinkTo>, <LinkTo kind="props" story="resource-title-accessor">resourceTitleAccessor</LinkTo> and <LinkTo kind="props" story="resources">resources</LinkTo> props to show events scheduled for different resources.
-        <br/>
+        The calendar below uses the{' '}
+        <LinkTo kind="props" story="resource-id-accessor">
+          resourceIdAccessor
+        </LinkTo>
+        ,{' '}
+        <LinkTo kind="props" story="resource-title-accessor">
+          resourceTitleAccessor
+        </LinkTo>{' '}
+        and{' '}
+        <LinkTo kind="props" story="resources">
+          resources
+        </LinkTo>{' '}
+        props to show events scheduled for different resources.
+        <br />
         Events can be mapped to a single resource, or multiple resources.
       </strong>
+      <div style={{ margin: '10px 0 20px 0' }}>
+        <label>
+          <input
+            type="checkbox"
+            checked={groupResourcesOnWeek}
+            onChange={() => setGroupResourcesOnWeek(!groupResourcesOnWeek)}
+          />
+          Group resources on week view.
+        </label>
+      </div>
       <div className="height600">
         <Calendar
           defaultDate={defaultDate}
@@ -71,6 +95,7 @@ export default function Resource({ localizer }) {
           resourceTitleAccessor="resourceTitle"
           step={60}
           views={views}
+          resourceGroupingLayout={groupResourcesOnWeek}
         />
       </div>
     </Fragment>


### PR DESCRIPTION
This pull request introduces conditional resource grouping, enhancing the flexibility and customization of resource display in the calendar. 

Addresses issue: https://github.com/jquense/react-big-calendar/issues/2008
Based on PR: https://github.com/jquense/react-big-calendar/pull/2609

## Key Changes:
- Introduced a new `TimeGridHeaderResources` component to render headers with grouped resources.
- Updated the TimeGrid component to support resource grouping based on the `resourceGroupingLayout` prop.
- Added the `resourceGroupingLayout` prop to the main Calendar component API. 
  This allows users to configure resource grouping at the top level, providing greater control over calendar display.
- Update **Resource Example** with Toggleable Grouping.

## Visual demonstration:

https://github.com/user-attachments/assets/42ef7537-7499-4081-b9fb-e8e63f665e99


