### PR TITLE
fix: add appearance: button for better cross-browser button styling c…

### DIFF
--- a/src/sass/reset.scss
+++ b/src/sass/reset.scss
@@ -7,7 +7,6 @@
 button.rbc-btn {
   overflow: visible;
   text-transform: none;
-  -webkit-appearance: button;
   appearance: button;
   cursor: pointer;
 }

--- a/src/sass/reset.scss
+++ b/src/sass/reset.scss
@@ -8,6 +8,7 @@ button.rbc-btn {
   overflow: visible;
   text-transform: none;
   -webkit-appearance: button;
+  appearance: button;
   cursor: pointer;
 }
 


### PR DESCRIPTION
Fixes: https://github.com/jquense/react-big-calendar/issues/2676

Currently, the CSS for button styling uses only -webkit-appearance: button, which ensures consistent styling across WebKit-based browsers (e.g., Chrome, Safari). However, the CSS property appearance: button is now part of the standard specification and is supported by a wider range of modern browsers, including Firefox.

To improve cross-browser compatibility and align with the CSS specification, we should include appearance: button in addition to -webkit-appearance: button. This will provide a more consistent button appearance across all major browsers that support the standard appearance property, while maintaining compatibility with older WebKit-based browsers via the -webkit-appearance fallback.

![스크린샷 2024-11-08 오후 11 36 27](https://github.com/user-attachments/assets/b80de8ce-6d9d-4be3-9a7e-168859db84a3)


Suggested solution
Add appearance: button; alongside -webkit-appearance: button; in the button CSS.
This will ensure that browsers supporting the standard appearance property apply it, while browsers that rely on -webkit-appearance will continue to function as expected.