### PR TITLE
fix: update doc type of onDropFromOutside function signature to include resource parameter

### DIFF
--- a/stories/addons/dragAndDrop/props/API.stories.mdx
+++ b/stories/addons/dragAndDrop/props/API.stories.mdx
@@ -25,7 +25,7 @@ A callback fired when user begins to drag an event.
 
 ### onDropFromOutside
 
-- type: `function ({ start, end, allDay }) => any`
+- type: `function ({ start, end, allDay, resource }) => any`
 - <LinkTo kind="addons-drag-and-drop-props" story="on-drop-from-outside">
     Example
   </LinkTo>

--- a/stories/addons/dragAndDrop/props/onDropFromOutside.mdx
+++ b/stories/addons/dragAndDrop/props/onDropFromOutside.mdx
@@ -3,7 +3,7 @@ import LinkTo from '@storybook/addon-links/react'
 
 # onDropFromOutside
 
-- type: `function ({ start, end, allDay }) => any`
+- type: `function ({ start, end, allDay, resource }) => any`
 
 A callback fired when user drops an item onto the Calendar from outside of the Calendar. Developers will typically use this method to add new items to the Calendar's <LinkTo kind="props" story="events">events</LinkTo>.
 


### PR DESCRIPTION
Recording to [this](https://github.com/jquense/react-big-calendar/blob/fea41753a1d3e7b1140b5a94496eb035fa58d313/src/addons/dragAndDrop/EventContainerWrapper.js#L125)
The function dose return resource
A PR has already been created on [@type](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71224) as well