### PR TITLE
Add handleInteractionEnd to dropFromOutside to cleanup preview.

### DIFF
--- a/src/addons/dragAndDrop/EventContainerWrapper.js
+++ b/src/addons/dragAndDrop/EventContainerWrapper.js
@@ -226,6 +226,8 @@ class EventContainerWrapper extends React.Component {
       const bounds = getBoundsForNode(node)
       if (!pointInColumn(bounds, point)) return
       this.handleDropFromOutside(point, bounds)
+      // cleanup the preview so that the state change from the user defined onDropFromOutside method is reflected.
+      this.handleInteractionEnd()
     })
 
     selector.on('dragOverFromOutside', (point) => {


### PR DESCRIPTION
Howdy,

I as well as a few other users have had a problem with trying to manually control the state for items dropped from outside.

Current behavior drops the preview onto the calendar. This is not desired as it interferes with trying to adjust the date and event after drop.

Use Case Example: Not allowing dropping from outside on specific calendar days.

Related issues
#2675
#2294

If you want me to change anything just let me know!