### PR TITLE
Allow disabling scroll when dragging behaviour

### DIFF
--- a/src/addons/dragAndDrop/EventContainerWrapper.js
+++ b/src/addons/dragAndDrop/EventContainerWrapper.js
@@ -155,6 +155,10 @@ class EventContainerWrapper extends React.Component {
   }
 
   updateParentScroll = (parent, node) => {
+    if(!this.context.draggable.autoscrollWhenDragging){
+      return
+    }
+
     setTimeout(() => {
       const draggedEl = qsa(node, '.rbc-addons-dnd-drag-preview')[0]
       if (draggedEl) {

--- a/src/addons/dragAndDrop/withDragAndDrop.js
+++ b/src/addons/dragAndDrop/withDragAndDrop.js
@@ -27,6 +27,8 @@ export default function withDragAndDrop(Calendar) {
 
       selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),
       resizable: PropTypes.bool,
+
+      autoscrollWhenDragging: PropTypes.bool
     }
 
     static defaultProps = {
@@ -34,6 +36,7 @@ export default function withDragAndDrop(Calendar) {
       draggableAccessor: null,
       resizableAccessor: null,
       resizable: true,
+      autoscrollWhenDragging: true
     }
 
     constructor(...args) {
@@ -53,6 +56,7 @@ export default function withDragAndDrop(Calendar) {
           draggableAccessor: this.props.draggableAccessor,
           resizableAccessor: this.props.resizableAccessor,
           dragAndDropAction: this.state,
+          autoscrollWhenDragging: this.props.autoscrollWhenDragging
         },
       }
     }

--- a/stories/addons/dragAndDrop/props/API.stories.mdx
+++ b/stories/addons/dragAndDrop/props/API.stories.mdx
@@ -100,3 +100,10 @@ The <LinkTo kind="addons-drag-and-drop-props" story="resizable">resizable</LinkT
 Determines if an event is resizable.
 
 **Note:** `resizable` events must also be draggable. You cannot resize an event with a <LinkTo kind="addons-drag-and-drop-props" story="draggable-accessor">draggableAccessor</LinkTo> prop of `false`.
+
+### autoscrollWhenDragging
+
+- type: `boolean`
+- default: `true`
+
+Determines if the calendar will scroll automatically when resizing or moving events


### PR DESCRIPTION
This PR allows disabling the autoscroll introduced by #2230, by adding a new prop (which defaults to true for backwards compatibility)

As noted in #2423 this can result in somewhat jumpy scrolling. It also causes issues with some layouts. for example if I load the sandbox at https://codesandbox.io/p/sandbox/react-big-calendar-example-forked-djgjc9, scroll down to the bottom of the page & resize an event then as soon as I start resizing the page jumps to the top
