### PR TITLE
fix: fix dayjs localizer merge function to not change min and max

### DIFF
--- a/src/localizers/dayjs.js
+++ b/src/localizers/dayjs.js
@@ -190,7 +190,8 @@ export default function (dayjsLib) {
     const tm = dayjs(time).format('HH:mm:ss')
     const dt = dayjs(date).startOf('day').format('MM/DD/YYYY')
     // We do it this way to avoid issues when timezone switching
-    return dayjsLib(`${dt} ${tm}`, 'MM/DD/YYYY HH:mm:ss').toDate()
+    const mergedDateTime = dayjs(`${dt} ${tm}`).toDate()
+    return dayjsLib(mergedDateTime).utc(true).toDate()
   }
 
   function add(date, adder, unit) {


### PR DESCRIPTION
Closes [#2688](https://github.com/jquense/react-big-calendar/issues/2688)

Fixes dayjs localizer merge function so min and max of the day stays always the same.
