### PR TITLE
fix(luxon): incorrect slot dates during DST changes

### DIFF
--- a/src/localizers/luxon.js
+++ b/src/localizers/luxon.js
@@ -272,7 +272,7 @@ export default function (DateTime, { firstDayOfWeek = 7 } = {}) {
 
   /**
    * Moved from TimeSlots.js, this method overrides the method of the same name
-   * in the localizer.js, using moment to construct the js Date
+   * in the localizer.js, using Luxon to construct the js Date
    * @param {Date} dt - date to start with
    * @param {Number} minutesFromMidnight
    * @param {Number} offset
@@ -280,7 +280,7 @@ export default function (DateTime, { firstDayOfWeek = 7 } = {}) {
    */
   function getSlotDate(dt, minutesFromMidnight, offset) {
     return startOfDT(dt, 'day')
-      .set({ minutes: minutesFromMidnight + offset })
+      .plus({ minutes: minutesFromMidnight + offset })
       .toJSDate()
   }
 


### PR DESCRIPTION
This PR fixes incorrect slot dates during DST changes when using the Luxon localizer.

DateTime.set() works with "wall clock" time - it sets the time as you'd see it on a wall clock, regardless of DST changes. DateTime.plus() works with actual elapsed time - it adds the specified duration, taking DST changes into account.

I've created a [small example](https://bolt.new/~/stackblitz-starters-gbxgrjhr) to demonstrate the problem:

```js
// Example using a DST transition in US (March 12, 2023, 2 AM -> 3 AM)
const beforeDST = DateTime.fromISO('2023-03-12T00:00:00', { zone: 'America/New_York' });

console.log('\n=== DateTime.set() during DST change ===');
// Using set() - maintains the wall clock time, adjusting for DST
console.log('After set({ hours: 1 }):', beforeDST.set({ hours: 1 }).toLocaleString(DateTime.DATETIME_FULL));
console.log('After set({ hours: 2 }):', beforeDST.set({ hours: 2 }).toLocaleString(DateTime.DATETIME_FULL));
console.log('After set({ hours: 3 }):', beforeDST.set({ hours: 3 }).toLocaleString(DateTime.DATETIME_FULL));

console.log('\n=== DateTime.plus() during DST change ===');
// Using plus() - adds actual hours, considering DST change
console.log('After plus({ hours: 1 }):', beforeDST.plus({ hours: 1 }).toLocaleString(DateTime.DATETIME_FULL));
console.log('After plus({ hours: 2 }):', beforeDST.plus({ hours: 2 }).toLocaleString(DateTime.DATETIME_FULL));
console.log('After plus({ hours: 3 }):', beforeDST.plus({ hours: 3 }).toLocaleString(DateTime.DATETIME_FULL));
```

```
=== DateTime.set() during DST change ===
After set({ hours: 1 }): 12 March 2023 at 01:00 GMT-5
After set({ hours: 2 }): 12 March 2023 at 03:00 GMT-4
After set({ hours: 3 }): 12 March 2023 at 03:00 GMT-4

=== DateTime.plus() during DST change ===
After plus({ hours: 1 }): 12 March 2023 at 01:00 GMT-5
After plus({ hours: 2 }): 12 March 2023 at 03:00 GMT-4
After plus({ hours: 3 }): 12 March 2023 at 04:00 GMT-4
```