### PR TITLE
fix: updated usage of Uncontrollable to fix issues in react 19

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { uncontrollable } from 'uncontrollable'
+import { useUncontrolled } from 'uncontrollable'
 import {
   accessor,
   views as componentViews,
@@ -1180,8 +1180,28 @@ class Calendar extends React.Component {
   }
 }
 
-export default uncontrollable(Calendar, {
-  view: 'onView',
-  date: 'onNavigate',
-  selected: 'onSelectEvent',
-})
+function UncontrolledCalendar(props) {
+  const controlledProps = useUncontrolled(props, {
+    view: 'onView',
+    date: 'onNavigate',
+    selected: 'onSelectEvent',
+  })
+
+  return <Calendar {...controlledProps} />
+}
+
+UncontrolledCalendar.propTypes = {
+  ...Calendar.propTypes,
+  view: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+  date: PropTypes.instanceOf(Date),
+  selected: PropTypes.object,
+}
+
+UncontrolledCalendar.defaultProps = {
+  ...Calendar.defaultProps,
+  view: views.MONTH,
+  date: new Date(),
+  selected: null,
+}
+
+export default UncontrolledCalendar


### PR DESCRIPTION
A solve for #2720.

A number of people have been complaining about issues related to the navigation, specifically in react 19. 

After doing some digging, I realize the issue revolves around the usage of another dependency from @jquense called [@jquense/uncontrollable](https://www.npmjs.com/package/uncontrollable). 

In that version of the library, the helper function designed to wrap `class components` is using`React.forwardRef`. Since it's been deprecated in React 19, I've opted to use the hook implementation. 

This PR is just demonstrative. I suggest we refactor the `Calendar` class component to be a functional component to be able to use the hook implementation of `@jquense/uncontrollable`.

**Temporary Solution:**
- Wrap Calendar in a functional component to utilize the more modern hook implementation included by the library.

**Proposed Solution:**
- Refactor Calendar to a functional component
- Use hook implementation of `@jquense/uncontrollable`
