### PR TITLE
Documenting the resourceAccessor prop in Storybook

### DIFF
--- a/stories/props/API.stories.mdx
+++ b/stories/props/API.stories.mdx
@@ -283,6 +283,15 @@ Resource {
 }
 ```
 
+### resourceAccessor
+
+- type: `string | function (resource: Object) => string | number // must be unique`
+- <LinkTo kind="props" story="resource-accessor">
+    Example
+  </LinkTo>
+
+Returns the unique identifier of the `resource` that each event in the <LinkTo kind="props" story="events">events</LinkTo> is a member of. This identifier should match at least one resource in the <LinkTo kind="props" story="resources">resources</LinkTo> array.
+
 ### resourceIdAccessor
 
 - type: `string | function (resource: Object) => string | number // must be unique`

--- a/stories/props/resourceAccessor.mdx
+++ b/stories/props/resourceAccessor.mdx
@@ -1,0 +1,11 @@
+import { Canvas, Story } from '@storybook/addon-docs'
+import LinkTo from '@storybook/addon-links/react'
+
+# resourceAccessor
+
+- type: `string | function (resource: Object) => string | number // must be unique`
+- <LinkTo kind="props" story="resource-accessor">
+    Example
+  </LinkTo>
+
+Returns the unique identifier of the `resource` that each event in the <LinkTo kind="props" story="events">events</LinkTo> is a member of. This identifier should match at least one resource in the <LinkTo kind="props" story="resources">resources</LinkTo> array.

--- a/stories/props/resourceAccessor.stories.js
+++ b/stories/props/resourceAccessor.stories.js
@@ -1,15 +1,13 @@
 import React from 'react'
 import { Calendar } from '../../src'
 import { resourceAccessorStoryArgs } from './storyDefaults'
-import mdx from './resourceTitleAccessor.mdx'
+import mdx from './resourceAccessor.mdx'
 
 export default {
   title: 'props',
   component: Calendar,
   argTypes: {
     localizer: { control: { type: null } },
-    events: { control: { type: null } },
-    resourceAccessor: { control: { type: null }},
     defaultDate: {
       control: {
         type: null,
@@ -34,6 +32,6 @@ const Template = (args) => (
   </div>
 )
 
-export const ResourceTitleAccessor = Template.bind({})
-ResourceTitleAccessor.storyName = 'resourceTitleAccessor'
-ResourceTitleAccessor.args = resourceAccessorStoryArgs
+export const ResourceAccessor = Template.bind({})
+ResourceAccessor.storyName = 'resourceAccessor'
+ResourceAccessor.args = resourceAccessorStoryArgs

--- a/stories/props/resourceIdAccessor.stories.js
+++ b/stories/props/resourceIdAccessor.stories.js
@@ -9,6 +9,7 @@ export default {
   argTypes: {
     localizer: { control: { type: null } },
     events: { control: { type: null } },
+    resourceAccessor: { control: { type: null }},
     defaultDate: {
       control: {
         type: null,

--- a/stories/props/storyDefaults.js
+++ b/stories/props/storyDefaults.js
@@ -14,10 +14,9 @@ const adjusted = demoEvents.map((event) => {
     end: endDate,
     title: label,
     allDay: allDayEvent,
-    resourceId: ResourceId
     ...other
   } = event
-  return { ...other, startDate, endDate, label, allDayEvent, ResourceId }
+  return { ...other, startDate, endDate, label, allDayEvent }
 })
 
 export const accessorStoryArgs = {
@@ -29,12 +28,18 @@ export const accessorStoryArgs = {
   titleAccessor: 'label',
   tooltipAccessor: 'label',
   startAccessor: 'startDate',
-  idAccessor: 'id',
-  resourceAccessor: 'ResourceId'
+  idAccessor: 'id'
 }
 /** END Specific to event key accessors */
 
 /** Specific to resource key accessors */
+const adjustedResourceEvents = resourceEvents.map((event) => {
+  const {
+    resourceId: ResourceId,
+    ...other
+  } = event;
+  return { ...other, ResourceId }
+})
 const adjustedResources = resources.map(({ id: Id, title: Title }) => ({
   Id,
   Title,
@@ -43,11 +48,11 @@ const adjustedResources = resources.map(({ id: Id, title: Title }) => ({
 export const resourceAccessorStoryArgs = {
   defaultDate: new Date(2015, 3, 4),
   defaultView: Views.DAY,
-  events: resourceEvents,
+  events: adjustedResourceEvents,
   localizer: mLocalizer,
   resourceIdAccessor: 'Id',
   resources: adjustedResources,
   resourceTitleAccessor: 'Title',
-  resourceAccessor: 'resourceId',
+  resourceAccessor: 'ResourceId',
 }
 /** END Specific to resource key accessors */

--- a/stories/props/storyDefaults.js
+++ b/stories/props/storyDefaults.js
@@ -14,9 +14,10 @@ const adjusted = demoEvents.map((event) => {
     end: endDate,
     title: label,
     allDay: allDayEvent,
+    resourceId: ResourceId
     ...other
   } = event
-  return { ...other, startDate, endDate, label, allDayEvent }
+  return { ...other, startDate, endDate, label, allDayEvent, ResourceId }
 })
 
 export const accessorStoryArgs = {
@@ -29,6 +30,7 @@ export const accessorStoryArgs = {
   tooltipAccessor: 'label',
   startAccessor: 'startDate',
   idAccessor: 'id',
+  resourceAccessor: 'ResourceId'
 }
 /** END Specific to event key accessors */
 
@@ -46,5 +48,6 @@ export const resourceAccessorStoryArgs = {
   resourceIdAccessor: 'Id',
   resources: adjustedResources,
   resourceTitleAccessor: 'Title',
+  resourceAccessor: 'resourceId',
 }
-/** ENDSpecific to resource key accessors */
+/** END Specific to resource key accessors */


### PR DESCRIPTION
The `resourceAccessor` prop is required if your event objects don't use `resourceId`, and while it has a docstring in the source code, it's missing from the Storybook docs.  This PR sets up the Markdoc and component for it, as well as updating the `storyDefault` props to show it varying.  My chosen text was pulled from the existing docstring in Calendar.js, but links to related props like the docs for the other resource accessors do:  

https://github.com/jquense/react-big-calendar/blob/7e6ee161b516ed62bbce5ba6923f53eae8323c37/src/Calendar.js#L239-L249

The `resourceIdAccessor` and `resourceTitleAccessor` still won't allow you to change the `events` and therefore the resource key, so I disabled edits on that param for those stories.  However, the `resourceAccessor` story will let you inspect & adjust both the `events` and `resources` arrays.  Other than that, I followed existing patterns wherever I could.