### PR TITLE
Fix cleanup error

### DIFF
--- a/src/addons/dragAndDrop/EventContainerWrapper.js
+++ b/src/addons/dragAndDrop/EventContainerWrapper.js
@@ -1,8 +1,8 @@
+import { scrollParent, scrollTop } from 'dom-helpers'
+import qsa from 'dom-helpers/cjs/querySelectorAll'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { DnDContext } from './DnDContext'
-import { scrollParent, scrollTop } from 'dom-helpers'
-import qsa from 'dom-helpers/cjs/querySelectorAll'
 
 import Selection, {
   getBoundsForNode,
@@ -110,24 +110,6 @@ class EventContainerWrapper extends React.Component {
     this.update(event, newRange)
   }
 
-  _cleanupPreviewElements = () => {
-    if (this.ref.current) {
-      const previewElements = qsa(
-        this.ref.current,
-        '.rbc-addons-dnd-drag-preview'
-      )
-      previewElements.forEach((el) => {
-        if (el.parentNode) {
-          try {
-            el.parentNode.removeChild(el)
-          } catch (err) {
-            // Ignore removal errors
-          }
-        }
-      })
-    }
-  }
-
   handleDropFromOutside = (point, boundaryBox) => {
     const { slotMetrics, resource } = this.props
 
@@ -145,9 +127,8 @@ class EventContainerWrapper extends React.Component {
       resource,
     })
 
+    // Cleanup after dropping from outside
     this.reset()
-    // Only call cleanup here, after dropping from outside
-    this._cleanupPreviewElements()
   }
 
   handleDragOverFromOutside = (point, bounds) => {


### PR DESCRIPTION
Fix my previous error from this PR: https://github.com/jquense/react-big-calendar/pull/2746

I was mistaken to add both _cleanup and this.reset() functions. Only one was necessary, the reset one.
This error appears, which it didn't appear during the testing part.

@cutterbl I am sorry about this. I saw it while trying to fork the library myself, didn't know when it would be merged :D 

It tries to cleanup an element that was already cleaned up, and so, the error appears.

<img width="436" alt="Screenshot 2025-05-28 at 20 17 35" src="https://github.com/user-attachments/assets/e268d82d-3d65-418e-b841-3fe0806fa685" />
