### PR TITLE
fix(accessibility): wrap +n more buttons in aria-compliant cells

### DIFF
--- a/src/DateContentRow.js
+++ b/src/DateContentRow.js
@@ -181,17 +181,23 @@ class DateContentRow extends React.Component {
             </div>
           )}
           <ScrollableWeekComponent>
-            <WeekWrapper isAllDay={isAllDay} {...eventRowProps} rtl={this.props.rtl}>
+            <WeekWrapper
+              isAllDay={isAllDay}
+              {...eventRowProps}
+              rtl={this.props.rtl}
+            >
               {levels.map((segs, idx) => (
                 <EventRow key={idx} segments={segs} {...eventRowProps} />
               ))}
-              {!!extra.length && (
-                <EventEndingRow
-                  segments={extra}
-                  onShowMore={this.handleShowMore}
-                  {...eventRowProps}
-                />
-              )}
+              <span role="cell">
+                {!!extra.length && (
+                  <EventEndingRow
+                    segments={extra}
+                    onShowMore={this.handleShowMore}
+                    {...eventRowProps}
+                  />
+                )}
+              </span>
             </WeekWrapper>
           </ScrollableWeekComponent>
         </div>


### PR DESCRIPTION
wrap +n more buttons in aria-compliant cells (EventEndingRow) by span with a role `cell`.

Problem: 
<img width="1728" alt="Screenshot 2025-06-15 at 7 39 31 PM" src="https://github.com/user-attachments/assets/a0bf1636-a0f0-445e-b2a0-5d45475850c7" />

Solution: 
- button fragment cannot be direct children of a row role'd element as guided by https://www.w3.org/TR/wai-aria/
- we should wrap it with `cell` so browser knows that it's a cell of a row. 
<img width="1728" alt="Screenshot 2025-06-15 at 7 41 02 PM" src="https://github.com/user-attachments/assets/fc9f9b93-440d-4abb-92f6-696c012a6071" />
