### PR TITLE
fix: updated deprecated @import and color functions usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ Out of the box, you can include the compiled CSS files and be up and running. Bu
 Big Calendar to match your application styling. For this reason, SASS files are included with Big Calendar.
 
 ```
-  @import 'react-big-calendar/lib/sass/styles';
-  @import 'react-big-calendar/lib/addons/dragAndDrop/styles'; // if using DnD
+  @use 'react-big-calendar/lib/sass/styles';
+  @use 'react-big-calendar/lib/addons/dragAndDrop/styles'; // if using DnD
 ```
 
 SASS implementation provides a `variables` file containing color and sizing variables that you can

--- a/docs/README-ar.md
+++ b/docs/README-ar.md
@@ -155,8 +155,8 @@ const MyCalendar = (props) => (
 التقويم الكبير ليتناسب مع تصميم التطبيق الخاص بك. لهذا السبب، تم تضمين ملفات SASS مع التقويم الكبير.
 
 ```
-  @import 'react-big-calendar/lib/sass/styles';
-  @import 'react-big-calendar/lib/addons/dragAndDrop/styles'; // if using DnD
+  @use 'react-big-calendar/lib/sass/styles';
+  @use 'react-big-calendar/lib/addons/dragAndDrop/styles'; // if using DnD
 ```
 
 توفر مكتبة SASS ملف `variables` يحتوي على متغيرات الألوان والأبعاد التي يمكنك تحديثها لتتناسب مع تطبيقك. _ملحوظة:_ يمكن أن يؤدي تغيير و/أو تجاوز الأنماط إلى حدوث مشكلات في التقديم مع تقويمك الكبير. قم بإجراء اختبارات دقيقة لكل تغيير وفقًا لذلك.

--- a/src/addons/dragAndDrop/styles.scss
+++ b/src/addons/dragAndDrop/styles.scss
@@ -1,4 +1,4 @@
-@import '../../sass/variables';
+@use '../../sass/variables';
 
 .rbc-addons-dnd {
   .rbc-addons-dnd-row-body {

--- a/src/sass/agenda.scss
+++ b/src/sass/agenda.scss
@@ -1,4 +1,4 @@
-@import './variables';
+@use './variables' as *;
 
 .rbc-agenda-view {
   display: flex;
@@ -69,5 +69,5 @@
 
 
 .rbc-agenda-event-cell {
-  width: 100%
+  width: 100%;
 }

--- a/src/sass/event.scss
+++ b/src/sass/event.scss
@@ -1,4 +1,4 @@
-@import './variables';
+@use './variables' as *;
 
 .rbc-event {
   border: none;

--- a/src/sass/event.scss
+++ b/src/sass/event.scss
@@ -19,7 +19,7 @@
   }
 
   &.rbc-selected {
-    background-color: darken($event-bg, 10%);
+    background-color: color.adjust($event-bg, $lightness: -10%, $space: hsl);
   }
 
   &:focus {

--- a/src/sass/month.scss
+++ b/src/sass/month.scss
@@ -28,7 +28,7 @@
   color: $event-bg;
   &:hover,
   &:focus {
-    color: darken($event-bg, 10%);
+    color: color.adjust($event-bg, $lightness: -10%, $space: hsl);
   }
 }
 

--- a/src/sass/month.scss
+++ b/src/sass/month.scss
@@ -1,4 +1,4 @@
-@import './variables';
+@use './variables' as *;
 
 .rbc-row {
   display: flex;

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -1,5 +1,5 @@
-@import './variables';
-@import './reset';
+@use './variables' as *;
+@use './reset';
 
 .rbc-calendar {
   box-sizing: border-box;
@@ -125,8 +125,8 @@
   background-color: $today-highlight-bg;
 }
 
-@import './toolbar';
-@import './event';
-@import './month';
-@import './agenda';
-@import './time-grid';
+@use './toolbar';
+@use './event';
+@use './month';
+@use './agenda';
+@use './time-grid';

--- a/src/sass/time-column.scss
+++ b/src/sass/time-column.scss
@@ -1,4 +1,4 @@
-@import './variables';
+@use './variables' as *;
 
 .rbc-time-column {
   display: flex;
@@ -9,7 +9,6 @@
     flex: 1;
   }
 }
-
 
 .rbc-timeslot-group {
   border-bottom: 1px solid $cell-border;
@@ -76,7 +75,8 @@
   }
 
   .rbc-time-slot {
-    border-top: 1px solid color.adjust($cell-border, $lightness: 10%, $space: hsl);
+    border-top: 1px solid
+      color.adjust($cell-border, $lightness: 10%, $space: hsl);
   }
 }
 

--- a/src/sass/time-column.scss
+++ b/src/sass/time-column.scss
@@ -76,7 +76,7 @@
   }
 
   .rbc-time-slot {
-    border-top: 1px solid lighten($cell-border, 10%);
+    border-top: 1px solid color.adjust($cell-border, $lightness: 10%, $space: hsl);
   }
 }
 

--- a/src/sass/time-grid.scss
+++ b/src/sass/time-grid.scss
@@ -1,5 +1,5 @@
-@import './variables';
-@import './time-column';
+@use './variables' as *;
+@use './time-column';
 
 .rbc-slot-selection {
   z-index: 10;

--- a/src/sass/toolbar.scss
+++ b/src/sass/toolbar.scss
@@ -1,7 +1,7 @@
 @import './variables';
 
-$active-background: darken($btn-bg, 10%);
-$active-border: darken($btn-border, 12%);
+$active-background: color.adjust($btn-bg, $lightness: -10%, $space: hsl);
+$active-border: color.adjust($btn-border, $lightness: -12%, $space: hsl);
 
 .rbc-toolbar {
   display: flex;
@@ -41,8 +41,8 @@ $active-border: darken($btn-border, 12%);
       &:hover,
       &:focus {
         color: $btn-color;
-        background-color: darken($btn-bg, 17%);
-        border-color: darken($btn-border, 25%);
+        background-color: color.adjust($btn-bg, $lightness: -17%, $space: hsl);
+        border-color: color.adjust($btn-bg, $lightness: -25%, $space: hsl);
       }
     }
 

--- a/src/sass/toolbar.scss
+++ b/src/sass/toolbar.scss
@@ -1,4 +1,4 @@
-@import './variables';
+@use './variables' as *;
 
 $active-background: color.adjust($btn-bg, $lightness: -10%, $space: hsl);
 $active-border: color.adjust($btn-border, $lightness: -12%, $space: hsl);
@@ -12,7 +12,7 @@ $active-border: color.adjust($btn-border, $lightness: -12%, $space: hsl);
   font-size: 16px;
 
   .rbc-toolbar-label {
-    flex-grow:1;
+    flex-grow: 1;
     padding: 0 10px;
     text-align: center;
   }
@@ -56,7 +56,7 @@ $active-border: color.adjust($btn-border, $lightness: -12%, $space: hsl);
       color: $btn-color;
       cursor: pointer;
       background-color: $active-background;
-          border-color: $active-border;
+      border-color: $active-border;
     }
   }
 }

--- a/src/sass/variables.scss
+++ b/src/sass/variables.scss
@@ -1,5 +1,5 @@
-$out-of-range-color: lighten(#333, 40%) !default;
-$out-of-range-bg-color: lighten(#333, 70%) !default;
+$out-of-range-color: color.adjust(#333, $lightness: 40%, $space: hsl) !default;
+$out-of-range-bg-color: color.adjust(#333, $lightness: 70%, $space: hsl) !default;
 
 $calendar-border: #ddd !default;
 $cell-border: #ddd !default;
@@ -14,7 +14,7 @@ $time-selection-bg-color: rgba(0, 0, 0, 0.5) !default;
 $date-selection-bg-color: rgba(0, 0, 0, 0.1) !default;
 
 $event-bg: #3174ad !default;
-$event-border: darken(#3174ad, 10%) !default;
+$event-border: color.adjust(#3174ad, $lightness: -10%, $space: hsl) !default;
 $event-outline: #3b99fc !default;
 $event-color: #fff !default;
 $event-border-radius: 5px !default;

--- a/stories/guides/CustomStyling.stories.mdx
+++ b/stories/guides/CustomStyling.stories.mdx
@@ -8,8 +8,8 @@ import LinkTo from '@storybook/addon-links/react'
 Out of the box, you can include the compiled CSS files and be up and running. But, sometimes, you may want to style Big Calendar to match your application styling. For this reason, SASS files are included with Big Calendar.
 
 ```sass
-@import 'react-big-calendar/lib/sass/styles';
-@import 'react-big-calendar/lib/addons/dragAndDrop/styles'; // if using DnD
+@use 'react-big-calendar/lib/sass/styles';
+@use 'react-big-calendar/lib/addons/dragAndDrop/styles'; // if using DnD
 ```
 
 SASS implementation provides a `variables` file containing color and sizing variables that you can update to fit your application. Note: Changing and/or overriding styles can cause rendering issues with your Big Calendar. Carefully test each change accordingly.

--- a/stories/resources/main.scss
+++ b/stories/resources/main.scss
@@ -2,8 +2,8 @@
  * As seen in ./.storybook/main.js, this file is used to provide
  * the Big Calendar styles in Storybook
  */
-@import '../../src/sass/styles.scss';
-@import '../../src/addons/dragAndDrop/styles.scss';
+@use '../../src/sass/styles.scss';
+@use '../../src/addons/dragAndDrop/styles.scss';
 
 .height600 {
   position: relative;
@@ -59,6 +59,10 @@
 
 .nonDraggable,
 .nonResizable {
-  background-color: color.adjust(#3174ad, $lightness: 40%, $space: hsl) !important;
+  background-color: color.adjust(
+    #3174ad,
+    $lightness: 40%,
+    $space: hsl
+  ) !important;
   color: black !important;
 }

--- a/stories/resources/main.scss
+++ b/stories/resources/main.scss
@@ -59,6 +59,6 @@
 
 .nonDraggable,
 .nonResizable {
-  background-color: lighten(#3174ad, 40) !important;
+  background-color: color.adjust(#3174ad, $lightness: 40%, $space: hsl) !important;
   color: black !important;
 }


### PR DESCRIPTION
Sass announced some breaking changes a while ago ([@import](https://sass-lang.com/documentation/breaking-changes/import/) and [color functions](https://sass-lang.com/documentation/breaking-changes/color-functions/) )

 Those two will be deprecated sometime in the future along with Sass 3.0.0 release and will stop working. (and it's really annoying having to deal with all those warnings when building)
 
 Addresses the issues: [#2670](https://github.com/jquense/react-big-calendar/issues/2670) and [#2246](https://github.com/jquense/react-big-calendar/issues/2246) 
 
 I've made the required changes and ran `npm run test` which passed, I don't know if any further testing is required but I'm willing to do any necessary changes to my PR to get this approved. 