### PR TITLE
fix(dragAndDrop): add guard for undefined dragFromOutsideItem

### DIFF
--- a/src/addons/dragAndDrop/EventContainerWrapper.js
+++ b/src/addons/dragAndDrop/EventContainerWrapper.js
@@ -145,10 +145,13 @@ class EventContainerWrapper extends React.Component {
 
   _calculateDnDEnd = (start) => {
     const { accessors, slotMetrics, localizer } = this.props
-    const event = this.context.draggable.dragFromOutsideItem()
-    const { duration: eventDuration } = eventTimes(event, accessors, localizer)
+    const event = this.context.draggable.dragFromOutsideItem ? this.context.draggable.dragFromOutsideItem() : null
 
     let end = slotMetrics.nextSlot(start)
+
+    if (!event) return end
+
+    const { duration: eventDuration } = eventTimes(event, accessors, localizer)
     const eventHasDuration = !isNaN(eventDuration)
     if (eventHasDuration) {
       const eventEndSlot = localizer.add(start, eventDuration, 'milliseconds')


### PR DESCRIPTION
Prevent 'is not a function' error by checking if dragFromOutsideItem is defined before calling it in _calculateDnDEnd methods.

Fixes #2780
