### PR TITLE
fix: month/week view events and grid misaligned

### DIFF
--- a/src/sass/month.scss
+++ b/src/sass/month.scss
@@ -26,6 +26,7 @@
   height: auto;
   line-height: normal;
   color: $event-bg;
+
   &:hover,
   &:focus {
     color: darken($event-bg, 10%);
@@ -60,7 +61,7 @@
 
   height: 100%; // ie-fix
 
-  & + & {
+  &+& {
     border-top: 1px solid $cell-border;
   }
 }
@@ -75,7 +76,8 @@
     font-weight: bold;
   }
 
-  > a {
+  >a {
+
     &,
     &:active,
     &:visited {
@@ -91,17 +93,16 @@
   flex-direction: row;
   flex: 1 0 0;
   overflow: hidden;
-  right: 1px;
 }
 
 .rbc-day-bg {
   flex: 1 0 0%;
 
-  & + & {
+  &+& {
     border-left: 1px solid $cell-border;
   }
 
-  .rbc-rtl & + & {
+  .rbc-rtl &+& {
     border-left-width: 0;
     border-right: 1px solid $cell-border;
   }
@@ -115,7 +116,7 @@
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.25);
   padding: 10px;
 
-  > * + * {
+  >*+* {
     margin-top: 1px;
   }
 }


### PR DESCRIPTION
## Reason
1. `.rbc-abs-full` sets `right: 0`, which makes the background fill the entire container.  
2. `.rbc-row-bg` overrides it with `right: 1px`, shrinking the background by 1px from the right.  
3. This causes a width mismatch between the background layer and the header layer.

## Related Issue
Fixes #2783 

## Changes
<!-- What's in this diff? List key changes -->
- Styles (Remove right: 1px; from .rbc-row-bg)

## Testing
<!-- How did you test these changes? -->
- [x] Local testing completed
- [ ] Unit tests pass
- [x] Manual testing done

# Sandbox Demo
## Screenshots/Video
### Before
<!-- Add screenshots or video for any UI changes/bug fixes etc -->
<img width="2028" height="1055" alt="Dia 2025-11-03 22 54 30" src="https://github.com/user-attachments/assets/ba5516c9-6414-4db2-98c1-5ea93607cb55" />
<img width="2028" height="855" alt="Dia 2025-11-03 22 54 46" src="https://github.com/user-attachments/assets/0f1b1f13-575a-4be7-be85-108f0fa4cb41" />

### After
<img width="2026" height="798" alt="Dia 2025-11-03 22 55 11" src="https://github.com/user-attachments/assets/1e203a7d-f029-438b-943b-f1d7eaeba67d" />
<img width="2030" height="792" alt="Dia 2025-11-03 22 55 25" src="https://github.com/user-attachments/assets/e650e8ad-b97d-4c8c-a249-fa0a75156713" />
