### PR TITLE
style: update month and time column styles

### DIFF
--- a/src/sass/month.scss
+++ b/src/sass/month.scss
@@ -7,7 +7,7 @@
 
 .rbc-row-segment {
   padding: 0 1px 1px 1px;
-
+  margin-bottom: 8px;
   .rbc-event-content {
     @extend .rbc-ellipsis;
   }
@@ -51,15 +51,14 @@
 }
 
 .rbc-month-row {
-  display: flex;
+  display: inline-table !important;
+  flex: 0 0 0 !important;
+  padding: 8px 0;
+  min-height: 100px !important;
   position: relative;
-  flex-direction: column;
-  flex: 1 0 0; // postcss will remove the 0px here hence the duplication below
   flex-basis: 0px;
   overflow: hidden;
-
-  height: 100%; // ie-fix
-
+  height: 100%;
   & + & {
     border-top: 1px solid $cell-border;
   }

--- a/src/sass/time-column.scss
+++ b/src/sass/time-column.scss
@@ -25,6 +25,7 @@
 
 .rbc-label {
   padding: 0 5px;
+  display: none;
 }
 
 .rbc-day-slot {

--- a/src/sass/time-grid.scss
+++ b/src/sass/time-grid.scss
@@ -110,6 +110,7 @@
   border-top: 2px solid $calendar-border;
   overflow-y: auto;
   position: relative;
+  display: none;
 
   > .rbc-time-gutter {
     flex: none;


### PR DESCRIPTION
- Added margin-bottom to .rbc-row-segment for better spacing.
- Changed .rbc-month-row display to inline-table and adjusted flex properties for layout consistency.
- Set .rbc-label display to none to hide it.
- Updated .rbc-time-grid to display none, likely for conditional rendering.

These changes enhance the layout and visibility of calendar components.

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/jquense/react-big-calendar/blob/master/CONTRIBUTING.md) when submitting a pull request.
