### PR TITLE
fix: guard handleDragStart in show-more popup (#2786)

### DIFF
--- a/src/Popup.js
+++ b/src/Popup.js
@@ -94,7 +94,9 @@ function Pop({
           slotEnd={slotEnd}
           selected={isSelected(event, selected)}
           draggable={true}
-          onDragStart={() => handleDragStart(event)}
+          onDragStart={() =>
+            typeof handleDragStart === 'function' && handleDragStart(event)
+          }
           onDragEnd={() => show()}
         />
       ))}


### PR DESCRIPTION
Fixes #2786

When the show-more popup is open and the user drags an event, the code called `handleDragStart` without checking if it was provided. That optional prop is not always set, which caused `Uncaught TypeError: handleDragStart is not a function`.

This change only calls `handleDragStart` when it is a function (`typeof handleDragStart === 'function'`), so the popup works when the prop is omitted.