### PR TITLE
fix(Month): preserve needLimitMeasure state set by resize listener

### DIFF
--- a/src/Month.js
+++ b/src/Month.js
@@ -40,7 +40,8 @@ class MonthView extends React.Component {
   static getDerivedStateFromProps({ date, localizer }, state) {
     return {
       date,
-      needLimitMeasure: localizer.neq(date, state.date, 'month'),
+      needLimitMeasure:
+        state.needLimitMeasure || localizer.neq(date, state.date, 'month'),
     }
   }
 


### PR DESCRIPTION
Fixes #2789

The resize handler sets `needLimitMeasure: true` to trigger a row limit recalculation, but `getDerivedStateFromProps` unconditionally overwrites it with `localizer.neq(date, state.date, 'month')` — which is `false` when the month hasn't changed. This causes `componentDidUpdate` to skip calling `measureRowLimit()`.

The fix preserves the existing `needLimitMeasure` state (set by resize) while still allowing the month-change detection to set it to `true`.