### PR TITLE
fix(a11y): add role=button and tabIndex to EventCell

### DIFF
--- a/src/EventCell.js
+++ b/src/EventCell.js
@@ -63,6 +63,8 @@ class EventCell extends React.Component {
         <div
           {...props}
           style={{ ...userProps.style, ...style }}
+          role="button"
+          tabIndex={0}
           className={clsx('rbc-event', className, userProps.className, {
             'rbc-selected': selected,
             'rbc-event-allday': showAsAllDay,


### PR DESCRIPTION
Fixes #2776

Month/allday view events (`EventCell`) were missing `role="button"` and `tabIndex={0}`, so screen readers could not identify them as interactive buttons. Time grid events (`TimeGridEvent`) already had these attributes.

Added the same `role="button"` and `tabIndex={0}` to `EventCell` so screen readers correctly announce these as buttons when navigating with keyboard.