### PR TITLE
fix(luxon): use standalone month tokens (LLL/LLLL) instead of MMM/MMMM

### DIFF
--- a/src/localizers/luxon.js
+++ b/src/localizers/luxon.js
@@ -5,10 +5,10 @@ function pluralizeUnit(unit) {
 }
 
 const weekRangeFormat = ({ start, end }, culture, local) =>
-  local.format(start, 'MMMM dd', culture) +
+  local.format(start, 'LLLL dd', culture) +
   ' – ' +
   // updated to use this localizer 'eq()' method
-  local.format(end, local.eq(start, end, 'month') ? 'dd' : 'MMMM dd', culture)
+  local.format(end, local.eq(start, end, 'month') ? 'dd' : 'LLLL dd', culture)
 
 const dateRangeFormat = ({ start, end }, culture, local) =>
   local.format(start, 'D', culture) + ' – ' + local.format(end, 'D', culture)
@@ -34,12 +34,12 @@ export const formats = {
 
   timeGutterFormat: 't',
 
-  monthHeaderFormat: 'MMMM yyyy',
-  dayHeaderFormat: 'EEEE MMM dd',
+  monthHeaderFormat: 'LLLL yyyy',
+  dayHeaderFormat: 'EEEE LLL dd',
   dayRangeHeaderFormat: weekRangeFormat,
   agendaHeaderFormat: dateRangeFormat,
 
-  agendaDateFormat: 'EEE MMM dd',
+  agendaDateFormat: 'EEE LLL dd',
   agendaTimeFormat: 't',
   agendaTimeRangeFormat: timeRangeFormat,
 }


### PR DESCRIPTION
Fixes #2599

The Luxon format tokens `MMM`/`MMMM` produce contextual month names, which are incorrect in some locales (e.g. Russian genitive "января" instead of "Январь", or broken output for Chinese). The standalone tokens `LLL`/`LLLL` are the correct form for calendar headers, where the month name appears on its own rather than as part of a full date phrase.

Changed `monthHeaderFormat`, `dayHeaderFormat`, `agendaDateFormat`, and `weekRangeFormat` to use `LLLL`/`LLL` accordingly.