### PR TITLE
fix: guard dragFromOutsideItem in _calculateDnDEnd when not provided

### DIFF
--- a/src/addons/dragAndDrop/EventContainerWrapper.js
+++ b/src/addons/dragAndDrop/EventContainerWrapper.js
@@ -145,6 +145,9 @@ class EventContainerWrapper extends React.Component {
 
   _calculateDnDEnd = (start) => {
     const { accessors, slotMetrics, localizer } = this.props
+    if (!this.context.draggable.dragFromOutsideItem) {
+      return slotMetrics.nextSlot(start)
+    }
     const event = this.context.draggable.dragFromOutsideItem()
     const { duration: eventDuration } = eventTimes(event, accessors, localizer)
 


### PR DESCRIPTION
Fixes #2780

When using `onDropFromOutside` without providing `dragFromOutsideItem`, dropping an external item crashes with `TypeError: dragFromOutsideItem is not a function`.

This happens because `_calculateDnDEnd` unconditionally calls `this.context.draggable.dragFromOutsideItem()`. The `dragOverFromOutside` handler already guards against this (line 235 in EventContainerWrapper), but the `dropFromOutside` -> `handleDropFromOutside` -> `_calculateDnDEnd` path does not.

Fix: early-return `slotMetrics.nextSlot(start)` when `dragFromOutsideItem` is not provided, matching the guard pattern already used in WeekWrapper.js.